### PR TITLE
[Breaking change] merge namespaces

### DIFF
--- a/Src/Untech.SharePoint.Client.Test/Converters/BuiltIn/ContentTypeIdFieldConverterTest.cs
+++ b/Src/Untech.SharePoint.Client.Test/Converters/BuiltIn/ContentTypeIdFieldConverterTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Untech.SharePoint.Common.Converters;
+using Untech.SharePoint.Converters;
 
 namespace Untech.SharePoint.Client.Converters.BuiltIn
 {

--- a/Src/Untech.SharePoint.Client.Test/Converters/BuiltIn/UrlFieldConverterTest.cs
+++ b/Src/Untech.SharePoint.Client.Test/Converters/BuiltIn/UrlFieldConverterTest.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using Microsoft.SharePoint.Client;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Untech.SharePoint.Common.Converters;
-using Untech.SharePoint.Common.Models;
+using Untech.SharePoint.Converters;
+using Untech.SharePoint.Models;
 
 namespace Untech.SharePoint.Client.Converters.BuiltIn
 {

--- a/Src/Untech.SharePoint.Client.Test/Data/BasicOperationsTest.cs
+++ b/Src/Untech.SharePoint.Client.Test/Data/BasicOperationsTest.cs
@@ -1,8 +1,9 @@
 using System.Linq;
 using Microsoft.SharePoint.Client;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Untech.SharePoint.Common.Spec;
-using Untech.SharePoint.Common.Spec.Models;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.Spec;
+using Untech.SharePoint.Spec.Models;
 
 namespace Untech.SharePoint.Client.Data
 {

--- a/Src/Untech.SharePoint.Client.Test/Data/Bootstrap.cs
+++ b/Src/Untech.SharePoint.Client.Test/Data/Bootstrap.cs
@@ -1,7 +1,6 @@
-﻿using Untech.SharePoint.Client.Configuration;
-using Untech.SharePoint.Common.Configuration;
-using Untech.SharePoint.Common.Spec.Models;
-using Untech.SharePoint.Common.Utils;
+﻿using Untech.SharePoint.Configuration;
+using Untech.SharePoint.Spec.Models;
+using Untech.SharePoint.Utils;
 
 namespace Untech.SharePoint.Client.Data
 {

--- a/Src/Untech.SharePoint.Client.Test/Data/ClientTestQueryExecutor.cs
+++ b/Src/Untech.SharePoint.Client.Test/Data/ClientTestQueryExecutor.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Microsoft.SharePoint.Client;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.TestTools.QueryTests;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.TestTools.QueryTests;
 
 namespace Untech.SharePoint.Client.Data
 {

--- a/Src/Untech.SharePoint.Client.Test/Data/QueryablePerfTest.cs
+++ b/Src/Untech.SharePoint.Client.Test/Data/QueryablePerfTest.cs
@@ -1,9 +1,10 @@
 ﻿using Microsoft.SharePoint.Client;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Untech.SharePoint.Client.Extensions;
-using Untech.SharePoint.Common.Spec;
-using Untech.SharePoint.Common.Spec.Models;
-using Untech.SharePoint.Common.TestTools.QueryTests;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.Spec;
+using Untech.SharePoint.Spec.Models;
+using Untech.SharePoint.TestTools.QueryTests;
 
 namespace Untech.SharePoint.Client.Data
 {

--- a/Src/Untech.SharePoint.Client.Test/Data/QueryableTest.cs
+++ b/Src/Untech.SharePoint.Client.Test/Data/QueryableTest.cs
@@ -1,7 +1,8 @@
 ﻿using Microsoft.SharePoint.Client;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Untech.SharePoint.Common.Spec;
-using Untech.SharePoint.Common.Spec.Models;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.Spec;
+using Untech.SharePoint.Spec.Models;
 
 namespace Untech.SharePoint.Client.Data
 {

--- a/Src/Untech.SharePoint.Client/(Configuration)/ClientConfig.cs
+++ b/Src/Untech.SharePoint.Client/(Configuration)/ClientConfig.cs
@@ -1,21 +1,19 @@
-﻿using Untech.SharePoint.Common.Configuration;
-
-namespace Untech.SharePoint.Server.Configuration
+﻿namespace Untech.SharePoint.Configuration
 {
 	/// <summary>
 	/// Provides static method for starting <see cref="ConfigBuilder"/> configuration.
 	/// </summary>
-	public static class ServerConfig
+	public static class ClientConfig
 	{
 		/// <summary>
 		/// Begins configuration of the <see cref="ConfigBuilder"/> instance.
 		/// </summary>
-		/// <returns>Config builder with registered built-in field converters from <see cref="Common"/> and <see cref="Server"/> assemblies.</returns>
+		/// <returns>Config builder with registered built-in field converters from <see cref="Common"/> and <see cref="Client"/> assemblies.</returns>
 		public static ConfigBuilder Begin()
 		{
 			return (new ConfigBuilder())
 				.RegisterConverters(n => n.AddFromAssembly(typeof(ConfigBuilder).Assembly))
-				.RegisterConverters(n => n.AddFromAssembly(typeof(ServerConfig).Assembly));
+				.RegisterConverters(n => n.AddFromAssembly(typeof(ClientConfig).Assembly));
 		}
 	}
 }

--- a/Src/Untech.SharePoint.Client/(Data)/SpClientCommonService.cs
+++ b/Src/Untech.SharePoint.Client/(Data)/SpClientCommonService.cs
@@ -1,15 +1,15 @@
 ﻿using System.Collections.Generic;
 using Microsoft.SharePoint.Client;
+using Untech.SharePoint.Client.Data;
 using Untech.SharePoint.Client.Data.Mapper;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Configuration;
-using Untech.SharePoint.Common.Converters;
-using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.MetaModels.Visitors;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Configuration;
+using Untech.SharePoint.Converters;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.MetaModels.Visitors;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Client.Data
+namespace Untech.SharePoint.Data
 {
 	/// <summary>
 	/// Represents service that use CSOM (i.e. SharePoint Client Object Model) and can be used inside <see cref="SpContext{TContext}"/>.

--- a/Src/Untech.SharePoint.Client/(Data)/SpClientContext.cs
+++ b/Src/Untech.SharePoint.Client/(Data)/SpClientContext.cs
@@ -2,12 +2,11 @@
 using System.Linq.Expressions;
 using Microsoft.SharePoint.Client;
 using Untech.SharePoint.Client.Extensions;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Configuration;
-using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Configuration;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Client.Data
+namespace Untech.SharePoint.Data
 {
 	/// <summary>
 	/// Represents base data context class for CSOM.

--- a/Src/Untech.SharePoint.Client/Converters/BuiltIn/CalculatedFieldConverter.cs
+++ b/Src/Untech.SharePoint.Client/Converters/BuiltIn/CalculatedFieldConverter.cs
@@ -2,9 +2,9 @@
 using System.Collections.Generic;
 using System.Globalization;
 using Microsoft.SharePoint.Client;
-using Untech.SharePoint.Common.Converters;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.Converters;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.Utils;
 
 namespace Untech.SharePoint.Client.Converters.BuiltIn
 {
@@ -42,8 +42,7 @@ namespace Untech.SharePoint.Client.Converters.BuiltIn
 		{
 			if (value == null) return default(T);
 
-			var errValue = value as FieldCalculatedErrorValue;
-			if (errValue != null)
+			if (value is FieldCalculatedErrorValue errValue)
 			{
 				throw new ArgumentException("Calculated field value is an error: " + errValue.ErrorMessage);
 			}

--- a/Src/Untech.SharePoint.Client/Converters/BuiltIn/ContentTypeIdConverter.cs
+++ b/Src/Untech.SharePoint.Client/Converters/BuiltIn/ContentTypeIdConverter.cs
@@ -1,7 +1,7 @@
-﻿using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Converters;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.Utils;
+﻿using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Converters;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.Utils;
 
 namespace Untech.SharePoint.Client.Converters.BuiltIn
 {

--- a/Src/Untech.SharePoint.Client/Converters/BuiltIn/GeolocationFieldConverter.cs
+++ b/Src/Untech.SharePoint.Client/Converters/BuiltIn/GeolocationFieldConverter.cs
@@ -1,10 +1,10 @@
 using System.Globalization;
 using Microsoft.SharePoint.Client;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Converters;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.Models;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Converters;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.Models;
+using Untech.SharePoint.Utils;
 
 namespace Untech.SharePoint.Client.Converters.BuiltIn
 {

--- a/Src/Untech.SharePoint.Client/Converters/BuiltIn/LookupFieldConverter.cs
+++ b/Src/Untech.SharePoint.Client/Converters/BuiltIn/LookupFieldConverter.cs
@@ -2,12 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.SharePoint.Client;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Converters;
-using Untech.SharePoint.Common.Extensions;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.Models;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Converters;
+using Untech.SharePoint.Extensions;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.Models;
+using Untech.SharePoint.Utils;
 
 namespace Untech.SharePoint.Client.Converters.BuiltIn
 {
@@ -60,7 +60,7 @@ namespace Untech.SharePoint.Client.Converters.BuiltIn
 			var fieldValues = (IEnumerable<FieldLookupValue>)value;
 			var lookupValues = fieldValues.Select(ConvertToObjRef).ToList();
 
-			if (!lookupValues.Any())
+			if (lookupValues.Count == 0)
 			{
 				return null;
 			}
@@ -80,7 +80,7 @@ namespace Untech.SharePoint.Client.Converters.BuiltIn
 
 			var lookupValues = ((IEnumerable<ObjectReference>)value).Distinct().ToList();
 
-			if (!lookupValues.Any())
+			if (lookupValues.Count == 0)
 			{
 				return null;
 			}
@@ -93,8 +93,7 @@ namespace Untech.SharePoint.Client.Converters.BuiltIn
 		{
 			if (value == null) return null;
 
-			var singleValue = value as ObjectReference;
-			if (singleValue != null)
+			if (value is ObjectReference singleValue)
 			{
 				return singleValue.Id.ToString();
 			}

--- a/Src/Untech.SharePoint.Client/Converters/BuiltIn/MultiChoiceFieldConverter.cs
+++ b/Src/Untech.SharePoint.Client/Converters/BuiltIn/MultiChoiceFieldConverter.cs
@@ -1,11 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Converters;
-using Untech.SharePoint.Common.Extensions;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Converters;
+using Untech.SharePoint.Extensions;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.Utils;
 
 namespace Untech.SharePoint.Client.Converters.BuiltIn
 {
@@ -51,14 +51,13 @@ namespace Untech.SharePoint.Client.Converters.BuiltIn
 		{
 			if (value == null) return "";
 
-			var singleValue = value as string;
-			if (singleValue != null)
+			if (value is string singleValue)
 			{
 				return string.Format(";#{0};#", singleValue);
 			}
 
 			var multiValue = ((IEnumerable<string>)value).Distinct().ToList();
-			return multiValue.Any() ? string.Format(";#{0};#", multiValue.JoinToString(";#")) : "";
+			return multiValue.Count > 0 ? string.Format(";#{0};#", multiValue.JoinToString(";#")) : "";
 		}
 	}
 }

--- a/Src/Untech.SharePoint.Client/Converters/BuiltIn/UrlFieldConverter.cs
+++ b/Src/Untech.SharePoint.Client/Converters/BuiltIn/UrlFieldConverter.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.SharePoint.Client;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Converters;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.Models;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Converters;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.Models;
 
 namespace Untech.SharePoint.Client.Converters.BuiltIn
 {

--- a/Src/Untech.SharePoint.Client/Converters/BuiltIn/UserFieldConverter.cs
+++ b/Src/Untech.SharePoint.Client/Converters/BuiltIn/UserFieldConverter.cs
@@ -2,12 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.SharePoint.Client;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Converters;
-using Untech.SharePoint.Common.Extensions;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.Models;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Converters;
+using Untech.SharePoint.Extensions;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.Models;
+using Untech.SharePoint.Utils;
 
 namespace Untech.SharePoint.Client.Converters.BuiltIn
 {
@@ -57,7 +57,7 @@ namespace Untech.SharePoint.Client.Converters.BuiltIn
 			var fieldValues = (IEnumerable<FieldUserValue>)value;
 			var userValues = fieldValues.Select(ConvertToUserInfo).ToList();
 
-			if (!userValues.Any())
+			if (userValues.Count == 0)
 			{
 				return null;
 			}
@@ -76,7 +76,7 @@ namespace Untech.SharePoint.Client.Converters.BuiltIn
 			}
 
 			var userValues = ((IEnumerable<UserInfo>)value).Distinct().ToList();
-			if (!userValues.Any())
+			if (userValues.Count == 0)
 			{
 				return null;
 			}
@@ -90,8 +90,7 @@ namespace Untech.SharePoint.Client.Converters.BuiltIn
 		{
 			if (value == null) return null;
 
-			var singleValue = value as UserInfo;
-			if (singleValue != null)
+			if (value is UserInfo singleValue)
 			{
 				return singleValue.Id.ToString();
 			}

--- a/Src/Untech.SharePoint.Client/Data/Mapper/MapperInitializer.cs
+++ b/Src/Untech.SharePoint.Client/Data/Mapper/MapperInitializer.cs
@@ -1,7 +1,7 @@
 using Microsoft.SharePoint.Client;
-using Untech.SharePoint.Common.Data.Mapper;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.MetaModels.Visitors;
+using Untech.SharePoint.Data.Mapper;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.MetaModels.Visitors;
 
 namespace Untech.SharePoint.Client.Data.Mapper
 {

--- a/Src/Untech.SharePoint.Client/Data/Mapper/StoreAccessor.cs
+++ b/Src/Untech.SharePoint.Client/Data/Mapper/StoreAccessor.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.SharePoint.Client;
-using Untech.SharePoint.Common.Data.Mapper;
-using Untech.SharePoint.Common.MetaModels;
+using Untech.SharePoint.Data.Mapper;
+using Untech.SharePoint.MetaModels;
 
 namespace Untech.SharePoint.Client.Data.Mapper
 {

--- a/Src/Untech.SharePoint.Client/Data/Mapper/TypeMapper.cs
+++ b/Src/Untech.SharePoint.Client/Data/Mapper/TypeMapper.cs
@@ -1,6 +1,6 @@
 using Microsoft.SharePoint.Client;
-using Untech.SharePoint.Common.Data.Mapper;
-using Untech.SharePoint.Common.MetaModels;
+using Untech.SharePoint.Data.Mapper;
+using Untech.SharePoint.MetaModels;
 
 namespace Untech.SharePoint.Client.Data.Mapper
 {

--- a/Src/Untech.SharePoint.Client/Data/RuntimeInfoLoader.cs
+++ b/Src/Untech.SharePoint.Client/Data/RuntimeInfoLoader.cs
@@ -1,11 +1,11 @@
 ﻿using System;
-using System.IO;
 using System.Linq;
 using Microsoft.SharePoint.Client;
 using Untech.SharePoint.Client.Extensions;
-using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.MetaModels.Visitors;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.MetaModels.Visitors;
+using Untech.SharePoint.Utils;
 
 namespace Untech.SharePoint.Client.Data
 {
@@ -50,7 +50,7 @@ namespace Untech.SharePoint.Client.Data
 		{
 			public ListInfoLoader(List spList)
 			{
-				Common.Utils.Guard.CheckNotNull(nameof(spList), spList);
+				Guard.CheckNotNull(nameof(spList), spList);
 
 				SpList = spList;
 			}

--- a/Src/Untech.SharePoint.Client/Data/SpListItemsProvider.cs
+++ b/Src/Untech.SharePoint.Client/Data/SpListItemsProvider.cs
@@ -4,10 +4,10 @@ using System.Linq;
 using Microsoft.SharePoint.Client;
 using Untech.SharePoint.Client.Extensions;
 using Untech.SharePoint.Client.Utils;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.Data.Mapper;
-using Untech.SharePoint.Common.MetaModels;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.Data.Mapper;
+using Untech.SharePoint.MetaModels;
 
 namespace Untech.SharePoint.Client.Data
 {
@@ -24,7 +24,6 @@ namespace Untech.SharePoint.Client.Data
 
 			_spList = clientContext.GetListByUrl(list.Url);
 		}
-
 
 		public override IEnumerable<string> GetAttachments(int id)
 		{
@@ -156,7 +155,6 @@ namespace Untech.SharePoint.Client.Data
 			}
 			_clientContext.ExecuteQuery();
 		}
-
 
 		private class UpdateItemInfo
 		{

--- a/Src/Untech.SharePoint.Common.Test/Configuration/ConfigBuilderTest.cs
+++ b/Src/Untech.SharePoint.Common.Test/Configuration/ConfigBuilderTest.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Untech.SharePoint.Common.Converters;
-using Untech.SharePoint.Common.Mappings.Annotation;
+using Untech.SharePoint.Converters;
+using Untech.SharePoint.Mappings.Annotation;
 
-namespace Untech.SharePoint.Common.Configuration
+namespace Untech.SharePoint.Configuration
 {
 	[TestClass]
 	public class ConfigBuilderTest

--- a/Src/Untech.SharePoint.Common.Test/Converters/BaseConverterTest.cs
+++ b/Src/Untech.SharePoint.Common.Test/Converters/BaseConverterTest.cs
@@ -1,14 +1,14 @@
 ﻿using System.Collections;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Configuration;
-using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.Mappings;
-using Untech.SharePoint.Common.Mappings.Annotation;
-using Untech.SharePoint.Common.MetaModels;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Configuration;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.Mappings;
+using Untech.SharePoint.Mappings.Annotation;
+using Untech.SharePoint.MetaModels;
 
-namespace Untech.SharePoint.Common.Converters
+namespace Untech.SharePoint.Converters
 {
 	public abstract class BaseConverterTest
 	{

--- a/Src/Untech.SharePoint.Common.Test/Converters/BuiltIn/BooleanConverterTest.cs
+++ b/Src/Untech.SharePoint.Common.Test/Converters/BuiltIn/BooleanConverterTest.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Untech.SharePoint.Common.Converters.BuiltIn
+namespace Untech.SharePoint.Converters.BuiltIn
 {
 	[TestClass]
 	public class BooleanConverterTest : BaseConverterTest

--- a/Src/Untech.SharePoint.Common.Test/Converters/BuiltIn/DateTimeConverterTest.cs
+++ b/Src/Untech.SharePoint.Common.Test/Converters/BuiltIn/DateTimeConverterTest.cs
@@ -1,7 +1,7 @@
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Untech.SharePoint.Common.Converters.BuiltIn
+namespace Untech.SharePoint.Converters.BuiltIn
 {
 	[TestClass]
 	public class DateTimeConverterTest : BaseConverterTest

--- a/Src/Untech.SharePoint.Common.Test/Converters/BuiltIn/GuidConverterTest.cs
+++ b/Src/Untech.SharePoint.Common.Test/Converters/BuiltIn/GuidConverterTest.cs
@@ -1,7 +1,7 @@
 using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Untech.SharePoint.Common.Converters.BuiltIn
+namespace Untech.SharePoint.Converters.BuiltIn
 {
 	[TestClass]
 	public class GuidConverterTest : BaseConverterTest

--- a/Src/Untech.SharePoint.Common.Test/Converters/BuiltIn/IntegerConverterTest.cs
+++ b/Src/Untech.SharePoint.Common.Test/Converters/BuiltIn/IntegerConverterTest.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Untech.SharePoint.Common.Converters.BuiltIn
+namespace Untech.SharePoint.Converters.BuiltIn
 {
 	[TestClass]
 	public class IntegerConverterTest : BaseConverterTest

--- a/Src/Untech.SharePoint.Common.Test/Converters/BuiltIn/NumberConverterTest.cs
+++ b/Src/Untech.SharePoint.Common.Test/Converters/BuiltIn/NumberConverterTest.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Untech.SharePoint.Common.Converters.BuiltIn
+namespace Untech.SharePoint.Converters.BuiltIn
 {
 	[TestClass]
 	public class NumberConverterTest : BaseConverterTest

--- a/Src/Untech.SharePoint.Common.Test/Converters/BuiltInFieldConverter.cs
+++ b/Src/Untech.SharePoint.Common.Test/Converters/BuiltInFieldConverter.cs
@@ -1,4 +1,4 @@
-﻿namespace Untech.SharePoint.Common.Converters
+﻿namespace Untech.SharePoint.Converters
 {
 	[SpFieldConverter("BUILT_IN_TEST_CONVERTER")]
 	public class BuiltInTestFieldConverter : IFieldConverter

--- a/Src/Untech.SharePoint.Common.Test/Converters/ConverterContext.cs
+++ b/Src/Untech.SharePoint.Common.Test/Converters/ConverterContext.cs
@@ -1,12 +1,12 @@
 ﻿using System.Diagnostics.CodeAnalysis;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Configuration;
-using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.Mappings;
-using Untech.SharePoint.Common.Mappings.Annotation;
-using Untech.SharePoint.Common.MetaModels;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Configuration;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.Mappings;
+using Untech.SharePoint.Mappings.Annotation;
+using Untech.SharePoint.MetaModels;
 
-namespace Untech.SharePoint.Common.Converters
+namespace Untech.SharePoint.Converters
 {
 	[UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
 	public enum ExampleEnum

--- a/Src/Untech.SharePoint.Common.Test/Converters/Custom/EnumFieldConverterTest.cs
+++ b/Src/Untech.SharePoint.Common.Test/Converters/Custom/EnumFieldConverterTest.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Runtime.Serialization;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Untech.SharePoint.Common.CodeAnnotations;
+using Untech.SharePoint.CodeAnnotations;
 
-namespace Untech.SharePoint.Common.Converters.Custom
+namespace Untech.SharePoint.Converters.Custom
 {
 	[TestClass]
 	public class EnumFieldConverterTest : BaseConverterTest

--- a/Src/Untech.SharePoint.Common.Test/Converters/Custom/JsonFieldConverterTest.cs
+++ b/Src/Untech.SharePoint.Common.Test/Converters/Custom/JsonFieldConverterTest.cs
@@ -2,7 +2,7 @@
 using System.Runtime.Serialization;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Untech.SharePoint.Common.Converters.Custom
+namespace Untech.SharePoint.Converters.Custom
 {
 	[TestClass]
 	public class JsonFieldConverterTest : BaseConverterTest

--- a/Src/Untech.SharePoint.Common.Test/Converters/Custom/KeyValueFieldConverterTest.cs
+++ b/Src/Untech.SharePoint.Common.Test/Converters/Custom/KeyValueFieldConverterTest.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Untech.SharePoint.Common.Converters.Custom
+namespace Untech.SharePoint.Converters.Custom
 {
 	[TestClass]
 	public class KeyValueFieldConverterTest : BaseConverterTest

--- a/Src/Untech.SharePoint.Common.Test/Converters/Custom/XmlFieldConverterTest.cs
+++ b/Src/Untech.SharePoint.Common.Test/Converters/Custom/XmlFieldConverterTest.cs
@@ -5,7 +5,7 @@ using System.Xml.Linq;
 using System.Xml.Serialization;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Untech.SharePoint.Common.Converters.Custom
+namespace Untech.SharePoint.Converters.Custom
 {
 	[TestClass]
 	public class XmlFieldConverterTest : BaseConverterTest

--- a/Src/Untech.SharePoint.Common.Test/Converters/FieldConverterCollectionTest.cs
+++ b/Src/Untech.SharePoint.Common.Test/Converters/FieldConverterCollectionTest.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Untech.SharePoint.Common.Converters
+namespace Untech.SharePoint.Converters
 {
 	[TestClass]
 	public class FieldConverterContainerTest

--- a/Src/Untech.SharePoint.Common.Test/Data/Translators/BaseExpressionTest.cs
+++ b/Src/Untech.SharePoint.Common.Test/Data/Translators/BaseExpressionTest.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Models;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Models;
 
-namespace Untech.SharePoint.Common.Data.Translators
+namespace Untech.SharePoint.Data.Translators
 {
 	public class BaseExpressionTest
 	{

--- a/Src/Untech.SharePoint.Common.Test/Data/Translators/BaseExpressionVisitorTest.cs
+++ b/Src/Untech.SharePoint.Common.Test/Data/Translators/BaseExpressionVisitorTest.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Data.Translators.Predicate;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Data.Translators.Predicate;
 
-namespace Untech.SharePoint.Common.Data.Translators
+namespace Untech.SharePoint.Data.Translators
 {
 	public abstract class BaseExpressionVisitorTest : BaseExpressionTest
 	{

--- a/Src/Untech.SharePoint.Common.Test/Data/Translators/CamlQueryTreeProcessorTest.cs
+++ b/Src/Untech.SharePoint.Common.Test/Data/Translators/CamlQueryTreeProcessorTest.cs
@@ -3,11 +3,11 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Data.QueryModels;
-using Untech.SharePoint.Common.Extensions;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Data.QueryModels;
+using Untech.SharePoint.Extensions;
 
-namespace Untech.SharePoint.Common.Data.Translators
+namespace Untech.SharePoint.Data.Translators
 {
 	[TestClass]
 	[SuppressMessage("ReSharper", "ReplaceWithSingleCallToAny")]

--- a/Src/Untech.SharePoint.Common.Test/Data/Translators/FakeQueryable.cs
+++ b/Src/Untech.SharePoint.Common.Test/Data/Translators/FakeQueryable.cs
@@ -4,7 +4,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 
-namespace Untech.SharePoint.Common.Data.Translators
+namespace Untech.SharePoint.Data.Translators
 {
 	public class FakeQueryable<T> : IOrderedQueryable<T>, IQueryProvider
 	{

--- a/Src/Untech.SharePoint.Common.Test/Data/Translators/Predicate/CamlPredicateProcessorTest.cs
+++ b/Src/Untech.SharePoint.Common.Test/Data/Translators/Predicate/CamlPredicateProcessorTest.cs
@@ -4,9 +4,9 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Untech.SharePoint.Common.Extensions;
+using Untech.SharePoint.Extensions;
 
-namespace Untech.SharePoint.Common.Data.Translators.Predicate
+namespace Untech.SharePoint.Data.Translators.Predicate
 {
 	[TestClass]
 	public class CamlPredicateProcessorTest : BaseExpressionTest

--- a/Src/Untech.SharePoint.Common.Test/Data/Translators/Predicate/EvaluatorTest.cs
+++ b/Src/Untech.SharePoint.Common.Test/Data/Translators/Predicate/EvaluatorTest.cs
@@ -2,7 +2,7 @@
 using System.Linq.Expressions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Untech.SharePoint.Common.Data.Translators.Predicate
+namespace Untech.SharePoint.Data.Translators.Predicate
 {
 	[TestClass]
 	public class EvaluatorTest : BaseExpressionVisitorTest

--- a/Src/Untech.SharePoint.Common.Test/Data/Translators/Predicate/InRewriterTest.cs
+++ b/Src/Untech.SharePoint.Common.Test/Data/Translators/Predicate/InRewriterTest.cs
@@ -2,9 +2,9 @@
 using System.Linq;
 using System.Linq.Expressions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Untech.SharePoint.Common.Extensions;
+using Untech.SharePoint.Extensions;
 
-namespace Untech.SharePoint.Common.Data.Translators.Predicate
+namespace Untech.SharePoint.Data.Translators.Predicate
 {
 	[TestClass]
 	public class InRewriterTest : BaseExpressionVisitorTest

--- a/Src/Untech.SharePoint.Common.Test/Data/Translators/Predicate/PushNotDownVisitorTest.cs
+++ b/Src/Untech.SharePoint.Common.Test/Data/Translators/Predicate/PushNotDownVisitorTest.cs
@@ -2,7 +2,7 @@
 using System.Linq.Expressions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Untech.SharePoint.Common.Data.Translators.Predicate
+namespace Untech.SharePoint.Data.Translators.Predicate
 {
 	[TestClass]
 	[SuppressMessage("ReSharper", "RedundantLogicalConditionalExpressionOperand")]

--- a/Src/Untech.SharePoint.Common.Test/Data/Translators/Predicate/RedundantConditionRemoverTest.cs
+++ b/Src/Untech.SharePoint.Common.Test/Data/Translators/Predicate/RedundantConditionRemoverTest.cs
@@ -2,7 +2,7 @@
 using System.Linq.Expressions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Untech.SharePoint.Common.Data.Translators.Predicate
+namespace Untech.SharePoint.Data.Translators.Predicate
 {
 	[TestClass]
 	public class RedundantConditionRemoverTest : BaseExpressionVisitorTest

--- a/Src/Untech.SharePoint.Common.Test/Data/Translators/Predicate/StringIsNullOrEmptyRewriterTest.cs
+++ b/Src/Untech.SharePoint.Common.Test/Data/Translators/Predicate/StringIsNullOrEmptyRewriterTest.cs
@@ -1,7 +1,7 @@
 ﻿using System.Linq.Expressions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Untech.SharePoint.Common.Data.Translators.Predicate
+namespace Untech.SharePoint.Data.Translators.Predicate
 {
 	[TestClass]
 	public class StringIsNullOrEmptyRewriterTest : BaseExpressionVisitorTest

--- a/Src/Untech.SharePoint.Common.Test/Data/Translators/Predicate/SwapComparisonVisitorTest.cs
+++ b/Src/Untech.SharePoint.Common.Test/Data/Translators/Predicate/SwapComparisonVisitorTest.cs
@@ -1,7 +1,7 @@
 ﻿using System.Linq.Expressions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Untech.SharePoint.Common.Data.Translators.Predicate
+namespace Untech.SharePoint.Data.Translators.Predicate
 {
 	[TestClass]
 	public class SwapComparisonVisitorTest : BaseExpressionVisitorTest

--- a/Src/Untech.SharePoint.Common.Test/Data/Translators/Predicate/XorRewriterTest.cs
+++ b/Src/Untech.SharePoint.Common.Test/Data/Translators/Predicate/XorRewriterTest.cs
@@ -1,7 +1,7 @@
 ﻿using System.Linq.Expressions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Untech.SharePoint.Common.Data.Translators.Predicate
+namespace Untech.SharePoint.Data.Translators.Predicate
 {
 	[TestClass]
 	public class XorRewriterTest : BaseExpressionVisitorTest

--- a/Src/Untech.SharePoint.Common.Test/Mappings/Annotation/AnnotatedContentTypeMappingTest.cs
+++ b/Src/Untech.SharePoint.Common.Test/Mappings/Annotation/AnnotatedContentTypeMappingTest.cs
@@ -1,11 +1,11 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Configuration;
-using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.MetaModels;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Configuration;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.MetaModels;
 
-namespace Untech.SharePoint.Common.Mappings.Annotation
+namespace Untech.SharePoint.Mappings.Annotation
 {
 	[TestClass]
 	[SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Local")]

--- a/Src/Untech.SharePoint.Common.Test/Mappings/Annotation/AnnotatedContextMappingTest.cs
+++ b/Src/Untech.SharePoint.Common.Test/Mappings/Annotation/AnnotatedContextMappingTest.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Configuration;
-using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.MetaModels;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Configuration;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.MetaModels;
 
-namespace Untech.SharePoint.Common.Mappings.Annotation
+namespace Untech.SharePoint.Mappings.Annotation
 {
 	[TestClass]
 	[SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Local")]

--- a/Src/Untech.SharePoint.Common.Test/Mappings/Annotation/AnnotatedFieldPartTest.cs
+++ b/Src/Untech.SharePoint.Common.Test/Mappings/Annotation/AnnotatedFieldPartTest.cs
@@ -1,12 +1,12 @@
 using System;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Configuration;
-using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.MetaModels;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Configuration;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.MetaModels;
 
-namespace Untech.SharePoint.Common.Mappings.Annotation
+namespace Untech.SharePoint.Mappings.Annotation
 {
 	[TestClass]
 	[SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Local")]

--- a/Src/Untech.SharePoint.Common.Test/Mappings/ClassLike/AnnouncmentItem.cs
+++ b/Src/Untech.SharePoint.Common.Test/Mappings/ClassLike/AnnouncmentItem.cs
@@ -1,4 +1,4 @@
-﻿namespace Untech.SharePoint.Common.Mappings.ClassLike
+﻿namespace Untech.SharePoint.Mappings.ClassLike
 {
 	public class AnnouncmentItem
 	{

--- a/Src/Untech.SharePoint.Common.Test/Mappings/ClassLike/ClassLikeMappingTest.cs
+++ b/Src/Untech.SharePoint.Common.Test/Mappings/ClassLike/ClassLikeMappingTest.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-namespace Untech.SharePoint.Common.Mappings.ClassLike
+namespace Untech.SharePoint.Mappings.ClassLike
 {
 	[TestClass]
 	public class ClassLikeMappingTest

--- a/Src/Untech.SharePoint.Common.Test/Mappings/ClassLike/EventItem.cs
+++ b/Src/Untech.SharePoint.Common.Test/Mappings/ClassLike/EventItem.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Untech.SharePoint.Common.Mappings.ClassLike
+namespace Untech.SharePoint.Mappings.ClassLike
 {
 	public class EventItem
 	{

--- a/Src/Untech.SharePoint.Common.Test/Mappings/ClassLike/MenuItem.cs
+++ b/Src/Untech.SharePoint.Common.Test/Mappings/ClassLike/MenuItem.cs
@@ -1,4 +1,4 @@
-﻿namespace Untech.SharePoint.Common.Mappings.ClassLike
+﻿namespace Untech.SharePoint.Mappings.ClassLike
 {
 	public class MenuItem
 	{

--- a/Src/Untech.SharePoint.Common.Test/Mappings/ClassLike/SmallDataContext.cs
+++ b/Src/Untech.SharePoint.Common.Test/Mappings/ClassLike/SmallDataContext.cs
@@ -1,7 +1,7 @@
-using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.Models;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.Models;
 
-namespace Untech.SharePoint.Common.Mappings.ClassLike
+namespace Untech.SharePoint.Mappings.ClassLike
 {
 	public class SmallDataContext : SpContext<SmallDataContext>
 	{

--- a/Src/Untech.SharePoint.Common.Test/Mappings/ClassLike/SmallDataContextMap.cs
+++ b/Src/Untech.SharePoint.Common.Test/Mappings/ClassLike/SmallDataContextMap.cs
@@ -1,4 +1,4 @@
-namespace Untech.SharePoint.Common.Mappings.ClassLike
+namespace Untech.SharePoint.Mappings.ClassLike
 {
 	public class SmallDataContextMap : ContextMap<SmallDataContext>
 	{

--- a/Src/Untech.SharePoint.Common.Test/Spec/AggregateQuerySpec.cs
+++ b/Src/Untech.SharePoint.Common.Test/Spec/AggregateQuerySpec.cs
@@ -2,11 +2,11 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using Untech.SharePoint.Common.Models;
-using Untech.SharePoint.Common.Spec.Models;
-using Untech.SharePoint.Common.TestTools.QueryTests;
+using Untech.SharePoint.Models;
+using Untech.SharePoint.Spec.Models;
+using Untech.SharePoint.TestTools.QueryTests;
 
-namespace Untech.SharePoint.Common.Spec
+namespace Untech.SharePoint.Spec
 {
 	/// <summary>
 	/// The aggregate methods are Aggregate, Average, Count, LongCount, Max, Min, and Sum.

--- a/Src/Untech.SharePoint.Common.Test/Spec/BasicOperationsSpec.cs
+++ b/Src/Untech.SharePoint.Common.Test/Spec/BasicOperationsSpec.cs
@@ -3,15 +3,15 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.Extensions;
-using Untech.SharePoint.Common.Models;
-using Untech.SharePoint.Common.Spec.Models;
-using Untech.SharePoint.Common.TestTools.DataGenerators;
-using Untech.SharePoint.Common.TestTools.Generators;
-using Untech.SharePoint.Common.TestTools.Generators.Basic;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.Extensions;
+using Untech.SharePoint.Models;
+using Untech.SharePoint.Spec.Models;
+using Untech.SharePoint.TestTools.DataGenerators;
+using Untech.SharePoint.TestTools.Generators;
+using Untech.SharePoint.TestTools.Generators.Basic;
 
-namespace Untech.SharePoint.Common.Spec
+namespace Untech.SharePoint.Spec
 {
 	public class BasicOperationsSpec
 	{

--- a/Src/Untech.SharePoint.Common.Test/Spec/FilteringQuerySpec.cs
+++ b/Src/Untech.SharePoint.Common.Test/Spec/FilteringQuerySpec.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Untech.SharePoint.Common.Extensions;
-using Untech.SharePoint.Common.Models;
-using Untech.SharePoint.Common.Spec.Models;
-using Untech.SharePoint.Common.TestTools.Comparers;
-using Untech.SharePoint.Common.TestTools.QueryTests;
+using Untech.SharePoint.Extensions;
+using Untech.SharePoint.Models;
+using Untech.SharePoint.Spec.Models;
+using Untech.SharePoint.TestTools.Comparers;
+using Untech.SharePoint.TestTools.QueryTests;
 
-namespace Untech.SharePoint.Common.Spec
+namespace Untech.SharePoint.Spec
 {
 	public class FilteringQuerySpec : ITestQueryProvider<NewsModel>, ITestQueryProvider<ProjectModel>,
 		ITestQueryProvider<TeamModel>

--- a/Src/Untech.SharePoint.Common.Test/Spec/Models/DataContext.cs
+++ b/Src/Untech.SharePoint.Common.Test/Spec/Models/DataContext.cs
@@ -1,7 +1,7 @@
-﻿using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.Mappings.Annotation;
+﻿using Untech.SharePoint.Data;
+using Untech.SharePoint.Mappings.Annotation;
 
-namespace Untech.SharePoint.Common.Spec.Models
+namespace Untech.SharePoint.Spec.Models
 {
 	public class DataContext : SpContext<DataContext>
 	{

--- a/Src/Untech.SharePoint.Common.Test/Spec/Models/EventModel.cs
+++ b/Src/Untech.SharePoint.Common.Test/Spec/Models/EventModel.cs
@@ -1,8 +1,8 @@
 using System;
-using Untech.SharePoint.Common.Mappings.Annotation;
-using Untech.SharePoint.Common.Models;
+using Untech.SharePoint.Mappings.Annotation;
+using Untech.SharePoint.Models;
 
-namespace Untech.SharePoint.Common.Spec.Models
+namespace Untech.SharePoint.Spec.Models
 {
 	[SpContentType]
 	public class EventModel : Entity

--- a/Src/Untech.SharePoint.Common.Test/Spec/Models/NewsModel.cs
+++ b/Src/Untech.SharePoint.Common.Test/Spec/Models/NewsModel.cs
@@ -1,7 +1,7 @@
-﻿using Untech.SharePoint.Common.Mappings.Annotation;
-using Untech.SharePoint.Common.Models;
+﻿using Untech.SharePoint.Mappings.Annotation;
+using Untech.SharePoint.Models;
 
-namespace Untech.SharePoint.Common.Spec.Models
+namespace Untech.SharePoint.Spec.Models
 {
 	[SpContentType]
 	public class NewsModel : Entity

--- a/Src/Untech.SharePoint.Common.Test/Spec/Models/ProjectModel.cs
+++ b/Src/Untech.SharePoint.Common.Test/Spec/Models/ProjectModel.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using Untech.SharePoint.Common.Mappings.Annotation;
-using Untech.SharePoint.Common.Models;
+using Untech.SharePoint.Mappings.Annotation;
+using Untech.SharePoint.Models;
 
-namespace Untech.SharePoint.Common.Spec.Models
+namespace Untech.SharePoint.Spec.Models
 {
 	[SpContentType]
 	public class ProjectModel : Entity

--- a/Src/Untech.SharePoint.Common.Test/Spec/Models/TeamModel.cs
+++ b/Src/Untech.SharePoint.Common.Test/Spec/Models/TeamModel.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
-using Untech.SharePoint.Common.Mappings.Annotation;
-using Untech.SharePoint.Common.Models;
+using Untech.SharePoint.Mappings.Annotation;
+using Untech.SharePoint.Models;
 
-namespace Untech.SharePoint.Common.Spec.Models
+namespace Untech.SharePoint.Spec.Models
 {
 	[SpContentType]
 	public class TeamModel : Entity

--- a/Src/Untech.SharePoint.Common.Test/Spec/OrderingQuerySpec.cs
+++ b/Src/Untech.SharePoint.Common.Test/Spec/OrderingQuerySpec.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Untech.SharePoint.Common.Spec.Models;
-using Untech.SharePoint.Common.TestTools.Comparers;
-using Untech.SharePoint.Common.TestTools.QueryTests;
+using Untech.SharePoint.Spec.Models;
+using Untech.SharePoint.TestTools.Comparers;
+using Untech.SharePoint.TestTools.QueryTests;
 
-namespace Untech.SharePoint.Common.Spec
+namespace Untech.SharePoint.Spec
 {
 	/// <summary>
 	/// The ordering methods are OrderBy, OrderByDescending, ThenBy, ThenByDescending, and Reverse.

--- a/Src/Untech.SharePoint.Common.Test/Spec/PagingQuerySpec.cs
+++ b/Src/Untech.SharePoint.Common.Test/Spec/PagingQuerySpec.cs
@@ -2,11 +2,11 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using Untech.SharePoint.Common.Spec.Models;
-using Untech.SharePoint.Common.TestTools.Comparers;
-using Untech.SharePoint.Common.TestTools.QueryTests;
+using Untech.SharePoint.Spec.Models;
+using Untech.SharePoint.TestTools.Comparers;
+using Untech.SharePoint.TestTools.QueryTests;
 
-namespace Untech.SharePoint.Common.Spec
+namespace Untech.SharePoint.Spec
 {
 	/// <summary>
 	/// Paging operations return a single, specific element from a sequence. The element methods are ElementAt, First, FirstOrDefault, Last, LastOrDefault, Single, Skip, Take, TakeWhile.

--- a/Src/Untech.SharePoint.Common.Test/Spec/ProjectionQuerySpec.cs
+++ b/Src/Untech.SharePoint.Common.Test/Spec/ProjectionQuerySpec.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Untech.SharePoint.Common.Spec.Models;
-using Untech.SharePoint.Common.TestTools.QueryTests;
+using Untech.SharePoint.Spec.Models;
+using Untech.SharePoint.TestTools.QueryTests;
 
-namespace Untech.SharePoint.Common.Spec
+namespace Untech.SharePoint.Spec
 {
 	public class ProjectionQuerySpec : ITestQueryProvider<NewsModel>
 	{

--- a/Src/Untech.SharePoint.Common.Test/Spec/QueryablePerfomance.cs
+++ b/Src/Untech.SharePoint.Common.Test/Spec/QueryablePerfomance.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Untech.SharePoint.Common.Spec.Models;
-using Untech.SharePoint.Common.TestTools.QueryTests;
+using Untech.SharePoint.Spec.Models;
+using Untech.SharePoint.TestTools.QueryTests;
 
-namespace Untech.SharePoint.Common.Spec
+namespace Untech.SharePoint.Spec
 {
 	public class QueryablePerfomance : ITestQueryProvider<NewsModel>
 	{

--- a/Src/Untech.SharePoint.Common.Test/Spec/QueryableSpec.cs
+++ b/Src/Untech.SharePoint.Common.Test/Spec/QueryableSpec.cs
@@ -1,11 +1,11 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.Spec.Models;
-using Untech.SharePoint.Common.TestTools.DataManagers;
-using Untech.SharePoint.Common.TestTools.QueryTests;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.Spec.Models;
+using Untech.SharePoint.TestTools.DataManagers;
+using Untech.SharePoint.TestTools.QueryTests;
 
-namespace Untech.SharePoint.Common.Spec
+namespace Untech.SharePoint.Spec
 {
 	public class QueryableSpec
 	{

--- a/Src/Untech.SharePoint.Common.Test/Spec/SetQuerySpec.cs
+++ b/Src/Untech.SharePoint.Common.Test/Spec/SetQuerySpec.cs
@@ -2,10 +2,10 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using Untech.SharePoint.Common.Spec.Models;
-using Untech.SharePoint.Common.TestTools.QueryTests;
+using Untech.SharePoint.Spec.Models;
+using Untech.SharePoint.TestTools.QueryTests;
 
-namespace Untech.SharePoint.Common.Spec
+namespace Untech.SharePoint.Spec
 {
 	/// <summary>
 	/// The set methods are All, Any, Concat, Contains, DefaultIfEmpty, Distinct, EqualAll, Except, Intersect, and Union.

--- a/Src/Untech.SharePoint.Common.Test/Untech.SharePoint.Common.Test.csproj
+++ b/Src/Untech.SharePoint.Common.Test/Untech.SharePoint.Common.Test.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net45;net461</TargetFrameworks>
     <Company>Sergey Svirsky</Company>
     <Copyright>Copyright \u00A9 Sergey Svirsky 2015</Copyright>
-    <RootNamespace>Untech.SharePoint.Common</RootNamespace>
+    <RootNamespace>Untech.SharePoint</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Src/Untech.SharePoint.Common/CodeAnnotations/Attributes.cs
+++ b/Src/Untech.SharePoint.Common/CodeAnnotations/Attributes.cs
@@ -9,7 +9,7 @@
 // ReSharper disable InconsistentNaming
 // ReSharper disable CheckNamespace
 
-namespace Untech.SharePoint.Common.CodeAnnotations
+namespace Untech.SharePoint.CodeAnnotations
 {
 	/// <summary>
 	/// Indicates that the value of the marked element could be <c>null</c> sometimes,

--- a/Src/Untech.SharePoint.Common/Collections/Container.cs
+++ b/Src/Untech.SharePoint.Common/Collections/Container.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Collections
+namespace Untech.SharePoint.Collections
 {
 	/// <summary>
 	/// Represents a collection of keys and values.

--- a/Src/Untech.SharePoint.Common/Collections/KeyedFactory.cs
+++ b/Src/Untech.SharePoint.Common/Collections/KeyedFactory.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using Untech.SharePoint.Common.CodeAnnotations;
+using Untech.SharePoint.CodeAnnotations;
 
-namespace Untech.SharePoint.Common.Collections
+namespace Untech.SharePoint.Collections
 {
 	/// <summary>
 	/// Represents a keyed objects factory.

--- a/Src/Untech.SharePoint.Common/Configuration/Config.cs
+++ b/Src/Untech.SharePoint.Common/Configuration/Config.cs
@@ -1,11 +1,11 @@
 ﻿using System;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Converters;
-using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.Mappings;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Converters;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.Mappings;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Configuration
+namespace Untech.SharePoint.Configuration
 {
 	/// <summary>
 	/// Represents configuration that is required by <see cref="SpContext{TContext}"/>.

--- a/Src/Untech.SharePoint.Common/Configuration/ConfigBuilder.cs
+++ b/Src/Untech.SharePoint.Common/Configuration/ConfigBuilder.cs
@@ -1,14 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Collections;
-using Untech.SharePoint.Common.Converters;
-using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.Extensions;
-using Untech.SharePoint.Common.Mappings;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Collections;
+using Untech.SharePoint.Converters;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.Extensions;
+using Untech.SharePoint.Mappings;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Configuration
+namespace Untech.SharePoint.Configuration
 {
 	/// <summary>
 	/// Represents class that can build <see cref="Config"/>.

--- a/Src/Untech.SharePoint.Common/Converters/BuiltIn/BooleanFieldConverter.cs
+++ b/Src/Untech.SharePoint.Common/Converters/BuiltIn/BooleanFieldConverter.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Extensions;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Extensions;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Converters.BuiltIn
+namespace Untech.SharePoint.Converters.BuiltIn
 {
 	[SpFieldConverter("Boolean")]
 	[UsedImplicitly]

--- a/Src/Untech.SharePoint.Common/Converters/BuiltIn/DateTimeFieldConverter.cs
+++ b/Src/Untech.SharePoint.Common/Converters/BuiltIn/DateTimeFieldConverter.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.MetaModels;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.MetaModels;
 
-namespace Untech.SharePoint.Common.Converters.BuiltIn
+namespace Untech.SharePoint.Converters.BuiltIn
 {
 	[SpFieldConverter("DateTime")]
 	[UsedImplicitly]
@@ -12,8 +12,8 @@ namespace Untech.SharePoint.Common.Converters.BuiltIn
 	{
 		private static readonly IReadOnlyDictionary<Type, Func<IFieldConverter>> s_typeConverters = new Dictionary<Type, Func<IFieldConverter>>
 		{
-			{typeof(DateTime), () => new DateTimeTypeConverter()},
-			{typeof(DateTime?), () => new NullableDateTimeTypeConverter()}
+			[typeof(DateTime)] = () => new DateTimeTypeConverter(),
+			[typeof(DateTime?)] = () => new NullableDateTimeTypeConverter()
 		};
 
 		public override void Initialize(MetaField field)

--- a/Src/Untech.SharePoint.Common/Converters/BuiltIn/GuidFieldConverter.cs
+++ b/Src/Untech.SharePoint.Common/Converters/BuiltIn/GuidFieldConverter.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.MetaModels;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.MetaModels;
 
-namespace Untech.SharePoint.Common.Converters.BuiltIn
+namespace Untech.SharePoint.Converters.BuiltIn
 {
 	[SpFieldConverter("Guid")]
 	[UsedImplicitly]
@@ -11,8 +11,8 @@ namespace Untech.SharePoint.Common.Converters.BuiltIn
 	{
 		private static readonly IReadOnlyDictionary<Type, Func<IFieldConverter>> s_typeConverters = new Dictionary<Type, Func<IFieldConverter>>
 		{
-			{typeof (Guid), () => new GuidTypeConverter()},
-			{typeof (Guid?), () => new NullableGuidTypeConverter()}
+			[typeof (Guid)] = () => new GuidTypeConverter(),
+			[typeof (Guid?)] = () => new NullableGuidTypeConverter()
 		};
 
 		public override void Initialize(MetaField field)

--- a/Src/Untech.SharePoint.Common/Converters/BuiltIn/IntegerFieldConverter.cs
+++ b/Src/Untech.SharePoint.Common/Converters/BuiltIn/IntegerFieldConverter.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Extensions;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Extensions;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Converters.BuiltIn
+namespace Untech.SharePoint.Converters.BuiltIn
 {
 	[SpFieldConverter("Integer")]
 	[SpFieldConverter("Counter")]

--- a/Src/Untech.SharePoint.Common/Converters/BuiltIn/NumberFieldConverter.cs
+++ b/Src/Untech.SharePoint.Common/Converters/BuiltIn/NumberFieldConverter.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Extensions;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Extensions;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Converters.BuiltIn
+namespace Untech.SharePoint.Converters.BuiltIn
 {
 	[SpFieldConverter("Number")]
 	[SpFieldConverter("Currency")]

--- a/Src/Untech.SharePoint.Common/Converters/BuiltIn/TextFieldConverter.cs
+++ b/Src/Untech.SharePoint.Common/Converters/BuiltIn/TextFieldConverter.cs
@@ -1,9 +1,9 @@
 ﻿using System;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Converters.BuiltIn
+namespace Untech.SharePoint.Converters.BuiltIn
 {
 	[SpFieldConverter("Text")]
 	[SpFieldConverter("Note")]

--- a/Src/Untech.SharePoint.Common/Converters/Custom/EnumFieldConverter.cs
+++ b/Src/Untech.SharePoint.Common/Converters/Custom/EnumFieldConverter.cs
@@ -2,12 +2,12 @@
 using System.ComponentModel;
 using System.Reflection;
 using System.Runtime.Serialization;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Extensions;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Extensions;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Converters.Custom
+namespace Untech.SharePoint.Converters.Custom
 {
 	/// <summary>
 	/// Represents field converter that can convert string to <see cref="Enum"/> and vice versa.

--- a/Src/Untech.SharePoint.Common/Converters/Custom/JsonFieldConverter.cs
+++ b/Src/Untech.SharePoint.Common/Converters/Custom/JsonFieldConverter.cs
@@ -1,8 +1,8 @@
 ﻿using Newtonsoft.Json;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Converters.Custom
+namespace Untech.SharePoint.Converters.Custom
 {
 	/// <summary>
 	/// Represents field converter that can convert JSON string to object and vice versa.

--- a/Src/Untech.SharePoint.Common/Converters/Custom/KeyValueFieldConverter.cs
+++ b/Src/Untech.SharePoint.Common/Converters/Custom/KeyValueFieldConverter.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Untech.SharePoint.Common.Extensions;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.Extensions;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Converters.Custom
+namespace Untech.SharePoint.Converters.Custom
 {
 	/// <summary>
 	/// Represents field converter that can convert string to <see cref="Dictionary{String,String}"/> and vice versa.

--- a/Src/Untech.SharePoint.Common/Converters/Custom/NumericRangeFieldConverter.cs
+++ b/Src/Untech.SharePoint.Common/Converters/Custom/NumericRangeFieldConverter.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Globalization;
-using Untech.SharePoint.Common.MetaModels;
+using Untech.SharePoint.MetaModels;
 
-namespace Untech.SharePoint.Common.Converters.Custom
+namespace Untech.SharePoint.Converters.Custom
 {
 	/// <summary>
 	/// Represents field converter that can convert string to <see cref="Tuple{Double,Double}"/> and vice versa.

--- a/Src/Untech.SharePoint.Common/Converters/Custom/XmlFieldConverter.cs
+++ b/Src/Untech.SharePoint.Common/Converters/Custom/XmlFieldConverter.cs
@@ -2,11 +2,11 @@
 using System.Text;
 using System.Xml;
 using System.Xml.Serialization;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Converters.Custom
+namespace Untech.SharePoint.Converters.Custom
 {
 	/// <summary>
 	/// Represents field converter that can convert XML to object and vice versa.

--- a/Src/Untech.SharePoint.Common/Converters/FieldConverterContainer.cs
+++ b/Src/Untech.SharePoint.Common/Converters/FieldConverterContainer.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using System.Linq;
 using System.Reflection;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Collections;
-using Untech.SharePoint.Common.Extensions;
-using Untech.SharePoint.Common.Utils;
-using Untech.SharePoint.Common.Utils.Reflection;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Collections;
+using Untech.SharePoint.Extensions;
+using Untech.SharePoint.Utils;
+using Untech.SharePoint.Utils.Reflection;
 
-namespace Untech.SharePoint.Common.Converters
+namespace Untech.SharePoint.Converters
 {
 	/// <summary>
 	/// Represents container of <see cref="IFieldConverter"/> types.

--- a/Src/Untech.SharePoint.Common/Converters/FieldConverterCreator.cs
+++ b/Src/Untech.SharePoint.Common/Converters/FieldConverterCreator.cs
@@ -1,9 +1,9 @@
-﻿using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.MetaModels.Visitors;
-using Untech.SharePoint.Common.Utils;
+﻿using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.MetaModels.Visitors;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Converters
+namespace Untech.SharePoint.Converters
 {
 	/// <summary>
 	/// Represents class that will instantiate <see cref="MetaField.Converter"/> for all <see cref="MetaField"/>.

--- a/Src/Untech.SharePoint.Common/Converters/FieldConverterException.cs
+++ b/Src/Untech.SharePoint.Common/Converters/FieldConverterException.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Runtime.Serialization;
 
-namespace Untech.SharePoint.Common.Converters
+namespace Untech.SharePoint.Converters
 {
 	/// <summary>
 	/// Represents errors that occurs with <see cref="IFieldConverter"/>.

--- a/Src/Untech.SharePoint.Common/Converters/FieldConverterFinder.cs
+++ b/Src/Untech.SharePoint.Common/Converters/FieldConverterFinder.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.MetaModels.Visitors;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.MetaModels.Visitors;
 
-namespace Untech.SharePoint.Common.Converters
+namespace Untech.SharePoint.Converters
 {
 	internal sealed class FieldConverterFinder : BaseMetaModelVisitor
 	{

--- a/Src/Untech.SharePoint.Common/Converters/FieldConverterInitializationException.cs
+++ b/Src/Untech.SharePoint.Common/Converters/FieldConverterInitializationException.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Runtime.Serialization;
-using Untech.SharePoint.Common.MetaModels;
+using Untech.SharePoint.MetaModels;
 
-namespace Untech.SharePoint.Common.Converters
+namespace Untech.SharePoint.Converters
 {
 	/// <summary>
 	/// Represents errors that occurs during <see cref="IFieldConverter"/> initialization.

--- a/Src/Untech.SharePoint.Common/Converters/FieldConverterWrapper.cs
+++ b/Src/Untech.SharePoint.Common/Converters/FieldConverterWrapper.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Converters
+namespace Untech.SharePoint.Converters
 {
 	internal class FieldConverterWrapper : IFieldConverter
 	{

--- a/Src/Untech.SharePoint.Common/Converters/IFieldConverter.cs
+++ b/Src/Untech.SharePoint.Common/Converters/IFieldConverter.cs
@@ -1,6 +1,6 @@
-﻿using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.MetaModels;
-namespace Untech.SharePoint.Common.Converters
+﻿using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.MetaModels;
+namespace Untech.SharePoint.Converters
 {
 	/// <summary>
 	/// Represents field converter interface.

--- a/Src/Untech.SharePoint.Common/Converters/IFieldConverterResolver.cs
+++ b/Src/Untech.SharePoint.Common/Converters/IFieldConverterResolver.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using Untech.SharePoint.Common.CodeAnnotations;
+using Untech.SharePoint.CodeAnnotations;
 
-namespace Untech.SharePoint.Common.Converters
+namespace Untech.SharePoint.Converters
 {
 	/// <summary>
 	/// Represents interface of <see cref="IFieldConverter"/> resolver.

--- a/Src/Untech.SharePoint.Common/Converters/MultiTypeFieldConverter.cs
+++ b/Src/Untech.SharePoint.Common/Converters/MultiTypeFieldConverter.cs
@@ -1,9 +1,9 @@
 ﻿using System;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Converters
+namespace Untech.SharePoint.Converters
 {
 	/// <summary>
 	/// Represents base field converter that supports multiple member types.

--- a/Src/Untech.SharePoint.Common/Converters/SPFieldConverterAttribute.cs
+++ b/Src/Untech.SharePoint.Common/Converters/SPFieldConverterAttribute.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using Untech.SharePoint.Common.CodeAnnotations;
+using Untech.SharePoint.CodeAnnotations;
 
-namespace Untech.SharePoint.Common.Converters
+namespace Untech.SharePoint.Converters
 {
 	/// <summary>
 	/// Specifies SP field type that can be converted by marked <see cref="IFieldConverter"/> class.

--- a/Src/Untech.SharePoint.Common/Data/BaseSpListItemsProvider.cs
+++ b/Src/Untech.SharePoint.Common/Data/BaseSpListItemsProvider.cs
@@ -1,14 +1,14 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Data.Mapper;
-using Untech.SharePoint.Common.Data.QueryModels;
-using Untech.SharePoint.Common.Data.Translators;
-using Untech.SharePoint.Common.Extensions;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Data.Mapper;
+using Untech.SharePoint.Data.QueryModels;
+using Untech.SharePoint.Data.Translators;
+using Untech.SharePoint.Extensions;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Data
+namespace Untech.SharePoint.Data
 {
 	/// <summary>
 	/// Represents base class for SP list items provider.

--- a/Src/Untech.SharePoint.Common/Data/Exceptions.cs
+++ b/Src/Untech.SharePoint.Common/Data/Exceptions.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Runtime.Serialization;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Data
+namespace Untech.SharePoint.Data
 {
 	/// <summary>
 	/// Represents errors that occurs during <see cref="MetaField"/> mapping.

--- a/Src/Untech.SharePoint.Common/Data/FieldRefModelComparer.cs
+++ b/Src/Untech.SharePoint.Common/Data/FieldRefModelComparer.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
-using Untech.SharePoint.Common.Data.QueryModels;
+using Untech.SharePoint.Data.QueryModels;
 
-namespace Untech.SharePoint.Common.Data
+namespace Untech.SharePoint.Data
 {
 	internal class FieldRefModelComparer : IEqualityComparer<FieldRefModel>
 	{

--- a/Src/Untech.SharePoint.Common/Data/GenericMethodDefinitionComparer.cs
+++ b/Src/Untech.SharePoint.Common/Data/GenericMethodDefinitionComparer.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.Reflection;
 
-namespace Untech.SharePoint.Common.Data
+namespace Untech.SharePoint.Data
 {
 	internal class GenericMethodDefinitionComparer : IEqualityComparer<MethodInfo>
 	{

--- a/Src/Untech.SharePoint.Common/Data/ICommonService.cs
+++ b/Src/Untech.SharePoint.Common/Data/ICommonService.cs
@@ -1,10 +1,10 @@
 ﻿using System.Collections.Generic;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Configuration;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.MetaModels.Visitors;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Configuration;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.MetaModels.Visitors;
 
-namespace Untech.SharePoint.Common.Data
+namespace Untech.SharePoint.Data
 {
 	/// <summary>
 	/// Represents interface of services that can be used inside <see cref="SpContext{TContext}"/>.

--- a/Src/Untech.SharePoint.Common/Data/ISpContext.cs
+++ b/Src/Untech.SharePoint.Common/Data/ISpContext.cs
@@ -1,8 +1,8 @@
-﻿using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Mappings;
-using Untech.SharePoint.Common.MetaModels;
+﻿using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Mappings;
+using Untech.SharePoint.MetaModels;
 
-namespace Untech.SharePoint.Common.Data
+namespace Untech.SharePoint.Data
 {
 	/// <summary>
 	/// Represents interface for SP data context types.

--- a/Src/Untech.SharePoint.Common/Data/ISpList.cs
+++ b/Src/Untech.SharePoint.Common/Data/ISpList.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Untech.SharePoint.Common.CodeAnnotations;
+using Untech.SharePoint.CodeAnnotations;
 
-namespace Untech.SharePoint.Common.Data
+namespace Untech.SharePoint.Data
 {
 	/// <summary>
 	/// Represents interface for work with SP lists.

--- a/Src/Untech.SharePoint.Common/Data/ISpListItemsProvider.cs
+++ b/Src/Untech.SharePoint.Common/Data/ISpListItemsProvider.cs
@@ -1,9 +1,9 @@
 ﻿using System.Collections.Generic;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Data.QueryModels;
-using Untech.SharePoint.Common.MetaModels;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Data.QueryModels;
+using Untech.SharePoint.MetaModels;
 
-namespace Untech.SharePoint.Common.Data
+namespace Untech.SharePoint.Data
 {
 	/// <summary>
 	/// Represents interface of SP list data accessor and items provider.

--- a/Src/Untech.SharePoint.Common/Data/Mapper/FieldMapper.cs
+++ b/Src/Untech.SharePoint.Common/Data/Mapper/FieldMapper.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Converters;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Converters;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Data.Mapper
+namespace Untech.SharePoint.Data.Mapper
 {
 	/// <summary>
 	/// Represents class that can map value from SP list field to the specified entity member.

--- a/Src/Untech.SharePoint.Common/Data/Mapper/IFieldAccessor.cs
+++ b/Src/Untech.SharePoint.Common/Data/Mapper/IFieldAccessor.cs
@@ -1,4 +1,4 @@
-﻿namespace Untech.SharePoint.Common.Data.Mapper
+﻿namespace Untech.SharePoint.Data.Mapper
 {
 	/// <summary>
 	/// Defines methods to access field values.

--- a/Src/Untech.SharePoint.Common/Data/Mapper/MemberAccessor.cs
+++ b/Src/Untech.SharePoint.Common/Data/Mapper/MemberAccessor.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Reflection;
-using Untech.SharePoint.Common.Utils.Reflection;
+using Untech.SharePoint.Utils.Reflection;
 
-namespace Untech.SharePoint.Common.Data.Mapper
+namespace Untech.SharePoint.Data.Mapper
 {
 	internal class MemberAccessor : IFieldAccessor<object>
 	{

--- a/Src/Untech.SharePoint.Common/Data/Mapper/StoreAccessor.cs
+++ b/Src/Untech.SharePoint.Common/Data/Mapper/StoreAccessor.cs
@@ -1,9 +1,9 @@
 ﻿using System;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Data.Mapper
+namespace Untech.SharePoint.Data.Mapper
 {
 	/// <summary>
 	/// Represents SP field accessor.

--- a/Src/Untech.SharePoint.Common/Data/Mapper/TypeMapper.cs
+++ b/Src/Untech.SharePoint.Common/Data/Mapper/TypeMapper.cs
@@ -2,14 +2,14 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Data.QueryModels;
-using Untech.SharePoint.Common.Extensions;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.Utils;
-using Untech.SharePoint.Common.Utils.Reflection;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Data.QueryModels;
+using Untech.SharePoint.Extensions;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.Utils;
+using Untech.SharePoint.Utils.Reflection;
 
-namespace Untech.SharePoint.Common.Data.Mapper
+namespace Untech.SharePoint.Data.Mapper
 {
 	/// <summary>
 	/// Represents class that can map SP List item to Entity.

--- a/Src/Untech.SharePoint.Common/Data/MemberInfoComparer.cs
+++ b/Src/Untech.SharePoint.Common/Data/MemberInfoComparer.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Reflection;
 
-namespace Untech.SharePoint.Common.Data
+namespace Untech.SharePoint.Data
 {
 	internal class MemberInfoComparer : IEqualityComparer<MemberInfo>
 	{

--- a/Src/Untech.SharePoint.Common/Data/MemberRefModelComparer.cs
+++ b/Src/Untech.SharePoint.Common/Data/MemberRefModelComparer.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
-using Untech.SharePoint.Common.Data.QueryModels;
+using Untech.SharePoint.Data.QueryModels;
 
-namespace Untech.SharePoint.Common.Data
+namespace Untech.SharePoint.Data
 {
 	internal class MemberRefModelComparer : IEqualityComparer<MemberRefModel>
 	{

--- a/Src/Untech.SharePoint.Common/Data/MethodUtils.cs
+++ b/Src/Untech.SharePoint.Common/Data/MethodUtils.cs
@@ -4,9 +4,9 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using Untech.SharePoint.Common.Extensions;
+using Untech.SharePoint.Extensions;
 
-namespace Untech.SharePoint.Common.Data
+namespace Untech.SharePoint.Data
 {
 	[SuppressMessage("ReSharper", "InvokeAsExtensionMethod")]
 	internal static class MethodUtils

--- a/Src/Untech.SharePoint.Common/Data/QueryModels/ComparisonModel.cs
+++ b/Src/Untech.SharePoint.Common/Data/QueryModels/ComparisonModel.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Collections.Generic;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Data.QueryModels
+namespace Untech.SharePoint.Data.QueryModels
 {
 	/// <summary>
 	/// Represents CAML comparison tags, like Eq, Neq and etc.
@@ -13,18 +13,18 @@ namespace Untech.SharePoint.Common.Data.QueryModels
 		private static readonly Dictionary<ComparisonOperator, ComparisonOperator> s_negateMap = new Dictionary
 			<ComparisonOperator, ComparisonOperator>
 		{
-			{ComparisonOperator.Eq, ComparisonOperator.Neq},
-			{ComparisonOperator.Geq, ComparisonOperator.Lt},
-			{ComparisonOperator.Gt, ComparisonOperator.Leq},
-			{ComparisonOperator.Leq, ComparisonOperator.Gt},
-			{ComparisonOperator.Lt, ComparisonOperator.Geq},
-			{ComparisonOperator.Neq, ComparisonOperator.Eq},
-			{ComparisonOperator.IsNotNull, ComparisonOperator.IsNull},
-			{ComparisonOperator.IsNull, ComparisonOperator.IsNotNull},
-			{ComparisonOperator.Includes, ComparisonOperator.NotIncludes},
-			{ComparisonOperator.NotIncludes, ComparisonOperator.Includes},
-			{ComparisonOperator.ContainsOrIncludes, ComparisonOperator.NotContainsOrIncludes},
-			{ComparisonOperator.NotContainsOrIncludes, ComparisonOperator.ContainsOrIncludes}
+			[ComparisonOperator.Eq] = ComparisonOperator.Neq,
+			[ComparisonOperator.Geq] = ComparisonOperator.Lt,
+			[ComparisonOperator.Gt] = ComparisonOperator.Leq,
+			[ComparisonOperator.Leq] = ComparisonOperator.Gt,
+			[ComparisonOperator.Lt] = ComparisonOperator.Geq,
+			[ComparisonOperator.Neq] = ComparisonOperator.Eq,
+			[ComparisonOperator.IsNotNull] = ComparisonOperator.IsNull,
+			[ComparisonOperator.IsNull] = ComparisonOperator.IsNotNull,
+			[ComparisonOperator.Includes] = ComparisonOperator.NotIncludes,
+			[ComparisonOperator.NotIncludes] = ComparisonOperator.Includes,
+			[ComparisonOperator.ContainsOrIncludes] = ComparisonOperator.NotContainsOrIncludes,
+			[ComparisonOperator.NotContainsOrIncludes] = ComparisonOperator.ContainsOrIncludes
 		};
 
 		/// <summary>

--- a/Src/Untech.SharePoint.Common/Data/QueryModels/ComparisonOperator.cs
+++ b/Src/Untech.SharePoint.Common/Data/QueryModels/ComparisonOperator.cs
@@ -1,6 +1,6 @@
-﻿using Untech.SharePoint.Common.CodeAnnotations;
+﻿using Untech.SharePoint.CodeAnnotations;
 
-namespace Untech.SharePoint.Common.Data.QueryModels
+namespace Untech.SharePoint.Data.QueryModels
 {
 	/// <summary>
 	/// Describes different types of comparison operations allowed in CAML.

--- a/Src/Untech.SharePoint.Common/Data/QueryModels/ContentTypeIdRefModel.cs
+++ b/Src/Untech.SharePoint.Common/Data/QueryModels/ContentTypeIdRefModel.cs
@@ -1,4 +1,4 @@
-namespace Untech.SharePoint.Common.Data.QueryModels
+namespace Untech.SharePoint.Data.QueryModels
 {
 	/// <summary>
 	/// Represents FieldRef tag in CAML query that associated with ContentTypeId field.

--- a/Src/Untech.SharePoint.Common/Data/QueryModels/FieldRefModel.cs
+++ b/Src/Untech.SharePoint.Common/Data/QueryModels/FieldRefModel.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Untech.SharePoint.Common.Data.QueryModels
+namespace Untech.SharePoint.Data.QueryModels
 {
 	/// <summary>
 	/// Represents FieldRef tag in CAML query.

--- a/Src/Untech.SharePoint.Common/Data/QueryModels/FieldRefType.cs
+++ b/Src/Untech.SharePoint.Common/Data/QueryModels/FieldRefType.cs
@@ -1,6 +1,6 @@
 ﻿using System.Reflection;
 
-namespace Untech.SharePoint.Common.Data.QueryModels
+namespace Untech.SharePoint.Data.QueryModels
 {
 	/// <summary>
 	/// Describes different types of <see cref="FieldRefModel"/>.

--- a/Src/Untech.SharePoint.Common/Data/QueryModels/KeyRefModel.cs
+++ b/Src/Untech.SharePoint.Common/Data/QueryModels/KeyRefModel.cs
@@ -1,4 +1,4 @@
-﻿namespace Untech.SharePoint.Common.Data.QueryModels
+﻿namespace Untech.SharePoint.Data.QueryModels
 {
 	/// <summary>
 	/// Represents FieldRef tag in CAML query that associated with key field, i.e. ID or BdcIdentity for external list.

--- a/Src/Untech.SharePoint.Common/Data/QueryModels/LogicalJoinModel.cs
+++ b/Src/Untech.SharePoint.Common/Data/QueryModels/LogicalJoinModel.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Data.QueryModels
+namespace Untech.SharePoint.Data.QueryModels
 {
 	/// <summary>
 	/// Represents CAML logical tags, like And, Or.

--- a/Src/Untech.SharePoint.Common/Data/QueryModels/LogicalJoinOperator.cs
+++ b/Src/Untech.SharePoint.Common/Data/QueryModels/LogicalJoinOperator.cs
@@ -1,6 +1,6 @@
-﻿using Untech.SharePoint.Common.CodeAnnotations;
+﻿using Untech.SharePoint.CodeAnnotations;
 
-namespace Untech.SharePoint.Common.Data.QueryModels
+namespace Untech.SharePoint.Data.QueryModels
 {
 	/// <summary>
 	/// Describes different types of logical operation allowed in CAML.

--- a/Src/Untech.SharePoint.Common/Data/QueryModels/MemberRefModel.cs
+++ b/Src/Untech.SharePoint.Common/Data/QueryModels/MemberRefModel.cs
@@ -1,9 +1,9 @@
 using System;
 using System.Reflection;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Data.QueryModels
+namespace Untech.SharePoint.Data.QueryModels
 {
 	/// <summary>
 	/// Represents FieldRef tag in CAML query that associated with the specified <see cref="MemberInfo"/>.

--- a/Src/Untech.SharePoint.Common/Data/QueryModels/OrderByModel.cs
+++ b/Src/Untech.SharePoint.Common/Data/QueryModels/OrderByModel.cs
@@ -1,7 +1,7 @@
-﻿using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Utils;
+﻿using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Data.QueryModels
+namespace Untech.SharePoint.Data.QueryModels
 {
 	/// <summary>
 	/// Represents CAML OrderBy tag.

--- a/Src/Untech.SharePoint.Common/Data/QueryModels/QueryModel.cs
+++ b/Src/Untech.SharePoint.Common/Data/QueryModels/QueryModel.cs
@@ -2,10 +2,10 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Extensions;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Extensions;
 
-namespace Untech.SharePoint.Common.Data.QueryModels
+namespace Untech.SharePoint.Data.QueryModels
 {
 	/// <summary>
 	/// Represents CAML Query tag.

--- a/Src/Untech.SharePoint.Common/Data/QueryModels/WhereModel.cs
+++ b/Src/Untech.SharePoint.Common/Data/QueryModels/WhereModel.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Untech.SharePoint.Common.CodeAnnotations;
+using Untech.SharePoint.CodeAnnotations;
 
-namespace Untech.SharePoint.Common.Data.QueryModels
+namespace Untech.SharePoint.Data.QueryModels
 {
 	/// <summary>
 	/// Represents base class for CAML logical and comparison tags.

--- a/Src/Untech.SharePoint.Common/Data/QueryModels/WhereType.cs
+++ b/Src/Untech.SharePoint.Common/Data/QueryModels/WhereType.cs
@@ -1,4 +1,4 @@
-namespace Untech.SharePoint.Common.Data.QueryModels
+namespace Untech.SharePoint.Data.QueryModels
 {
 	/// <summary>
 	/// Describes different types of <see cref="WhereModel"/>

--- a/Src/Untech.SharePoint.Common/Data/SpContext.cs
+++ b/Src/Untech.SharePoint.Common/Data/SpContext.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.Linq.Expressions;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Extensions;
-using Untech.SharePoint.Common.Mappings;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Extensions;
+using Untech.SharePoint.Mappings;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Data
+namespace Untech.SharePoint.Data
 {
 	/// <summary>
 	/// Represents base data context.

--- a/Src/Untech.SharePoint.Common/Data/SpLinqQuery.cs
+++ b/Src/Untech.SharePoint.Common/Data/SpLinqQuery.cs
@@ -3,9 +3,9 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Data
+namespace Untech.SharePoint.Data
 {
 	internal class SpLinqQuery<T> : IOrderedQueryable<T>
 	{

--- a/Src/Untech.SharePoint.Common/Data/SpLinqQueryProvider.cs
+++ b/Src/Untech.SharePoint.Common/Data/SpLinqQueryProvider.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Linq;
 using System.Linq.Expressions;
-using Untech.SharePoint.Common.Data.Translators;
-using Untech.SharePoint.Common.Extensions;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.Data.Translators;
+using Untech.SharePoint.Extensions;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Data
+namespace Untech.SharePoint.Data
 {
 	internal class SpLinqQueryProvider : IQueryProvider
 	{

--- a/Src/Untech.SharePoint.Common/Data/SpList.cs
+++ b/Src/Untech.SharePoint.Common/Data/SpList.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Data
+namespace Untech.SharePoint.Data
 {
 	internal class SpList<T> : SpLinqQuery<T>, ISpList<T>
 	{

--- a/Src/Untech.SharePoint.Common/Data/SpListOptions.cs
+++ b/Src/Untech.SharePoint.Common/Data/SpListOptions.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Untech.SharePoint.Common.Data
+namespace Untech.SharePoint.Data
 {
 	/// <summary>
 	/// Describes different options for <see cref="ISpList{T}"/> configuration.

--- a/Src/Untech.SharePoint.Common/Data/SpQueryable.cs
+++ b/Src/Untech.SharePoint.Common/Data/SpQueryable.cs
@@ -2,11 +2,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Data.QueryModels;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Data.QueryModels;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Data
+namespace Untech.SharePoint.Data
 {
 	[UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
 	internal static class SpQueryable

--- a/Src/Untech.SharePoint.Common/Data/Translators/CamlQueryTranslator.cs
+++ b/Src/Untech.SharePoint.Common/Data/Translators/CamlQueryTranslator.cs
@@ -1,15 +1,15 @@
 ﻿using System;
 using System.Linq;
 using System.Xml.Linq;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Converters;
-using Untech.SharePoint.Common.Data.QueryModels;
-using Untech.SharePoint.Common.Diagnostics;
-using Untech.SharePoint.Common.Extensions;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Converters;
+using Untech.SharePoint.Data.QueryModels;
+using Untech.SharePoint.Diagnostics;
+using Untech.SharePoint.Extensions;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Data.Translators
+namespace Untech.SharePoint.Data.Translators
 {
 	internal class CamlQueryTranslator : IProcessor<QueryModel, string>
 	{

--- a/Src/Untech.SharePoint.Common/Data/Translators/CamlQueryTreeProcessor.cs
+++ b/Src/Untech.SharePoint.Common/Data/Translators/CamlQueryTreeProcessor.cs
@@ -3,14 +3,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Data.QueryModels;
-using Untech.SharePoint.Common.Data.Translators.Predicate;
-using Untech.SharePoint.Common.Diagnostics;
-using Untech.SharePoint.Common.Extensions;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Data.QueryModels;
+using Untech.SharePoint.Data.Translators.Predicate;
+using Untech.SharePoint.Diagnostics;
+using Untech.SharePoint.Extensions;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Data.Translators
+namespace Untech.SharePoint.Data.Translators
 {
 	internal sealed class CamlQueryTreeProcessor : IProcessor<Expression, Expression>
 	{

--- a/Src/Untech.SharePoint.Common/Data/Translators/IProcessor.cs
+++ b/Src/Untech.SharePoint.Common/Data/Translators/IProcessor.cs
@@ -1,6 +1,6 @@
-using Untech.SharePoint.Common.CodeAnnotations;
+using Untech.SharePoint.CodeAnnotations;
 
-namespace Untech.SharePoint.Common.Data.Translators
+namespace Untech.SharePoint.Data.Translators
 {
 	[PublicAPI]
 	internal interface IProcessor<in TIn, out TOut>

--- a/Src/Untech.SharePoint.Common/Data/Translators/Predicate/CamlFieldSelectorProcessor.cs
+++ b/Src/Untech.SharePoint.Common/Data/Translators/Predicate/CamlFieldSelectorProcessor.cs
@@ -1,11 +1,11 @@
 ﻿using System.Linq.Expressions;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Data.QueryModels;
-using Untech.SharePoint.Common.Diagnostics;
-using Untech.SharePoint.Common.Extensions;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Data.QueryModels;
+using Untech.SharePoint.Diagnostics;
+using Untech.SharePoint.Extensions;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Data.Translators.Predicate
+namespace Untech.SharePoint.Data.Translators.Predicate
 {
 	internal class CamlFieldSelectorProcessor : IProcessor<Expression, MemberRefModel>
 	{

--- a/Src/Untech.SharePoint.Common/Data/Translators/Predicate/CamlPredicateProcessor.cs
+++ b/Src/Untech.SharePoint.Common/Data/Translators/Predicate/CamlPredicateProcessor.cs
@@ -1,13 +1,13 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Data.QueryModels;
-using Untech.SharePoint.Common.Diagnostics;
-using Untech.SharePoint.Common.Extensions;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Data.QueryModels;
+using Untech.SharePoint.Diagnostics;
+using Untech.SharePoint.Extensions;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Data.Translators.Predicate
+namespace Untech.SharePoint.Data.Translators.Predicate
 {
 	internal class CamlPredicateProcessor : IProcessor<Expression, WhereModel>
 	{

--- a/Src/Untech.SharePoint.Common/Data/Translators/Predicate/CamlProcessorUtils.cs
+++ b/Src/Untech.SharePoint.Common/Data/Translators/Predicate/CamlProcessorUtils.cs
@@ -1,10 +1,10 @@
 ﻿using System.Linq.Expressions;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Data.QueryModels;
-using Untech.SharePoint.Common.Extensions;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Data.QueryModels;
+using Untech.SharePoint.Extensions;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Data.Translators.Predicate
+namespace Untech.SharePoint.Data.Translators.Predicate
 {
 	internal static class CamlProcessorUtils
 	{

--- a/Src/Untech.SharePoint.Common/Data/Translators/Predicate/CamlSelectableFieldsProcessor.cs
+++ b/Src/Untech.SharePoint.Common/Data/Translators/Predicate/CamlSelectableFieldsProcessor.cs
@@ -1,11 +1,11 @@
 ﻿using System.Collections.Generic;
 using System.Linq.Expressions;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Data.QueryModels;
-using Untech.SharePoint.Common.Diagnostics;
-using Untech.SharePoint.Common.Extensions;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Data.QueryModels;
+using Untech.SharePoint.Diagnostics;
+using Untech.SharePoint.Extensions;
 
-namespace Untech.SharePoint.Common.Data.Translators.Predicate
+namespace Untech.SharePoint.Data.Translators.Predicate
 {
 	internal class CamlSelectableFieldsProcessor : ExpressionVisitor, IProcessor<Expression, IEnumerable<MemberRefModel>>
 	{

--- a/Src/Untech.SharePoint.Common/Data/Translators/Predicate/Evaluator.cs
+++ b/Src/Untech.SharePoint.Common/Data/Translators/Predicate/Evaluator.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Linq.Expressions;
-using Untech.SharePoint.Common.CodeAnnotations;
+using Untech.SharePoint.CodeAnnotations;
 
-namespace Untech.SharePoint.Common.Data.Translators.Predicate
+namespace Untech.SharePoint.Data.Translators.Predicate
 {
 	internal class Evaluator : ExpressionVisitor
 	{
@@ -31,14 +31,14 @@ namespace Untech.SharePoint.Common.Data.Translators.Predicate
 				_candidates = candidates;
 			}
 
-			public override Expression Visit(Expression exp)
+			public override Expression Visit(Expression node)
 			{
-				if (exp == null)
+				if (node == null)
 				{
 					return null;
 				}
 
-				return _candidates.Contains(exp) ? Evaluate(exp) : base.Visit(exp);
+				return _candidates.Contains(node) ? Evaluate(node) : base.Visit(node);
 			}
 
 			private static Expression Evaluate(Expression e)

--- a/Src/Untech.SharePoint.Common/Data/Translators/Predicate/InRewriter.cs
+++ b/Src/Untech.SharePoint.Common/Data/Translators/Predicate/InRewriter.cs
@@ -1,10 +1,10 @@
 ﻿using System.Collections;
 using System.Linq;
 using System.Linq.Expressions;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Extensions;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Extensions;
 
-namespace Untech.SharePoint.Common.Data.Translators.Predicate
+namespace Untech.SharePoint.Data.Translators.Predicate
 {
 	internal class InRewriter : ExpressionVisitor
 	{

--- a/Src/Untech.SharePoint.Common/Data/Translators/Predicate/Nominator.cs
+++ b/Src/Untech.SharePoint.Common/Data/Translators/Predicate/Nominator.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq.Expressions;
 
-namespace Untech.SharePoint.Common.Data.Translators.Predicate
+namespace Untech.SharePoint.Data.Translators.Predicate
 {
 	internal sealed class Nominator : ExpressionVisitor
 	{

--- a/Src/Untech.SharePoint.Common/Data/Translators/Predicate/PushNotDownVisitor.cs
+++ b/Src/Untech.SharePoint.Common/Data/Translators/Predicate/PushNotDownVisitor.cs
@@ -1,9 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using Untech.SharePoint.Common.Extensions;
+using Untech.SharePoint.Extensions;
 
-namespace Untech.SharePoint.Common.Data.Translators.Predicate
+namespace Untech.SharePoint.Data.Translators.Predicate
 {
 	internal class PushNotDownVisitor : ExpressionVisitor
 	{

--- a/Src/Untech.SharePoint.Common/Data/Translators/Predicate/RedundantConditionRemover.cs
+++ b/Src/Untech.SharePoint.Common/Data/Translators/Predicate/RedundantConditionRemover.cs
@@ -1,7 +1,7 @@
 ﻿using System.Linq.Expressions;
-using Untech.SharePoint.Common.Extensions;
+using Untech.SharePoint.Extensions;
 
-namespace Untech.SharePoint.Common.Data.Translators.Predicate
+namespace Untech.SharePoint.Data.Translators.Predicate
 {
 	internal class RedundantConditionRemover : ExpressionVisitor
 	{

--- a/Src/Untech.SharePoint.Common/Data/Translators/Predicate/StringIsNullOrEmptyRewriter.cs
+++ b/Src/Untech.SharePoint.Common/Data/Translators/Predicate/StringIsNullOrEmptyRewriter.cs
@@ -1,6 +1,6 @@
 ﻿using System.Linq.Expressions;
 
-namespace Untech.SharePoint.Common.Data.Translators.Predicate
+namespace Untech.SharePoint.Data.Translators.Predicate
 {
 	internal class StringIsNullOrEmptyRewriter : ExpressionVisitor
 	{

--- a/Src/Untech.SharePoint.Common/Data/Translators/Predicate/SwapComparisonVisitor.cs
+++ b/Src/Untech.SharePoint.Common/Data/Translators/Predicate/SwapComparisonVisitor.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Linq.Expressions;
 
-namespace Untech.SharePoint.Common.Data.Translators.Predicate
+namespace Untech.SharePoint.Data.Translators.Predicate
 {
 	internal class SwapComparisonVisitor : ExpressionVisitor
 	{

--- a/Src/Untech.SharePoint.Common/Data/Translators/Predicate/XorRewriter.cs
+++ b/Src/Untech.SharePoint.Common/Data/Translators/Predicate/XorRewriter.cs
@@ -1,6 +1,6 @@
 ﻿using System.Linq.Expressions;
 
-namespace Untech.SharePoint.Common.Data.Translators.Predicate
+namespace Untech.SharePoint.Data.Translators.Predicate
 {
 	internal class XorRewriter : ExpressionVisitor
 	{

--- a/Src/Untech.SharePoint.Common/Diagnostics/DebuggerLoggingEndpoint.cs
+++ b/Src/Untech.SharePoint.Common/Diagnostics/DebuggerLoggingEndpoint.cs
@@ -1,8 +1,8 @@
 ﻿using System.Diagnostics;
 using System.Threading;
-using Untech.SharePoint.Common.CodeAnnotations;
+using Untech.SharePoint.CodeAnnotations;
 
-namespace Untech.SharePoint.Common.Diagnostics
+namespace Untech.SharePoint.Diagnostics
 {
 	/// <summary>
 	/// Represents class of logging endpoint that writes messages to <see cref="Debugger"/> instance.

--- a/Src/Untech.SharePoint.Common/Diagnostics/ILoggingEndpoint.cs
+++ b/Src/Untech.SharePoint.Common/Diagnostics/ILoggingEndpoint.cs
@@ -1,4 +1,4 @@
-﻿namespace Untech.SharePoint.Common.Diagnostics
+﻿namespace Untech.SharePoint.Diagnostics
 {
 	/// <summary>
 	/// Represents interface of logging endpoint.

--- a/Src/Untech.SharePoint.Common/Diagnostics/LogCategories.cs
+++ b/Src/Untech.SharePoint.Common/Diagnostics/LogCategories.cs
@@ -1,4 +1,4 @@
-﻿namespace Untech.SharePoint.Common.Diagnostics
+﻿namespace Untech.SharePoint.Diagnostics
 {
 	internal static class LogCategories
 	{

--- a/Src/Untech.SharePoint.Common/Diagnostics/LogLevel.cs
+++ b/Src/Untech.SharePoint.Common/Diagnostics/LogLevel.cs
@@ -1,6 +1,6 @@
-﻿using Untech.SharePoint.Common.CodeAnnotations;
+﻿using Untech.SharePoint.CodeAnnotations;
 
-namespace Untech.SharePoint.Common.Diagnostics
+namespace Untech.SharePoint.Diagnostics
 {
 	/// <summary>
 	/// Describes different levels of logging message.

--- a/Src/Untech.SharePoint.Common/Diagnostics/Logger.cs
+++ b/Src/Untech.SharePoint.Common/Diagnostics/Logger.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Diagnostics
+namespace Untech.SharePoint.Diagnostics
 {
 	/// <summary>
 	/// Represents class that logs any message to specified endpoints.

--- a/Src/Untech.SharePoint.Common/Extensions/EnumerableExtensions.cs
+++ b/Src/Untech.SharePoint.Common/Extensions/EnumerableExtensions.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Extensions
+namespace Untech.SharePoint.Extensions
 {
 	/// <summary>
 	/// Provide a set of static methods for work with <see cref="IEnumerable{T}"/>.

--- a/Src/Untech.SharePoint.Common/Extensions/ExpressionExtensions.cs
+++ b/Src/Untech.SharePoint.Common/Extensions/ExpressionExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using System.Linq.Expressions;
 
-namespace Untech.SharePoint.Common.Extensions
+namespace Untech.SharePoint.Extensions
 {
 	internal static class ExpressionExtensions
 	{

--- a/Src/Untech.SharePoint.Common/Extensions/ObjectExtensions.cs
+++ b/Src/Untech.SharePoint.Common/Extensions/ObjectExtensions.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Untech.SharePoint.Common.CodeAnnotations;
+using Untech.SharePoint.CodeAnnotations;
 
-namespace Untech.SharePoint.Common.Extensions
+namespace Untech.SharePoint.Extensions
 {
 	/// <summary>
 	/// Provides a set of static methods for work with <see cref="object"/>.

--- a/Src/Untech.SharePoint.Common/Extensions/TypeExtensions.cs
+++ b/Src/Untech.SharePoint.Common/Extensions/TypeExtensions.cs
@@ -2,10 +2,10 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Extensions
+namespace Untech.SharePoint.Extensions
 {
 	/// <summary>
 	/// Provides a set of static method that can be used with <see cref="Type"/> and <see cref="System.Reflection"/>

--- a/Src/Untech.SharePoint.Common/Fields.cs
+++ b/Src/Untech.SharePoint.Common/Fields.cs
@@ -1,4 +1,4 @@
-﻿namespace Untech.SharePoint.Common
+﻿namespace Untech.SharePoint
 {
 	internal static class Fields
 	{

--- a/Src/Untech.SharePoint.Common/Mappings/Annotation/AnnotatedContentTypeMapping.cs
+++ b/Src/Untech.SharePoint.Common/Mappings/Annotation/AnnotatedContentTypeMapping.cs
@@ -2,11 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.MetaModels.Providers;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.MetaModels.Providers;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Mappings.Annotation
+namespace Untech.SharePoint.Mappings.Annotation
 {
 	internal class AnnotatedContentTypeMapping : IMetaContentTypeProvider
 	{

--- a/Src/Untech.SharePoint.Common/Mappings/Annotation/AnnotatedContextMapping.cs
+++ b/Src/Untech.SharePoint.Common/Mappings/Annotation/AnnotatedContextMapping.cs
@@ -2,10 +2,10 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.MetaModels.Providers;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.MetaModels.Providers;
 
-namespace Untech.SharePoint.Common.Mappings.Annotation
+namespace Untech.SharePoint.Mappings.Annotation
 {
 	internal class AnnotatedContextMapping<T> : IMetaContextProvider, IListUrlResolver
 	{

--- a/Src/Untech.SharePoint.Common/Mappings/Annotation/AnnotatedFieldPart.cs
+++ b/Src/Untech.SharePoint.Common/Mappings/Annotation/AnnotatedFieldPart.cs
@@ -1,11 +1,11 @@
 using System;
 using System.Linq;
 using System.Reflection;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.MetaModels.Providers;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.MetaModels.Providers;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Mappings.Annotation
+namespace Untech.SharePoint.Mappings.Annotation
 {
 	internal class AnnotatedFieldPart : IMetaFieldProvider
 	{

--- a/Src/Untech.SharePoint.Common/Mappings/Annotation/AnnotatedListPart.cs
+++ b/Src/Untech.SharePoint.Common/Mappings/Annotation/AnnotatedListPart.cs
@@ -2,13 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.Extensions;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.MetaModels.Providers;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.Extensions;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.MetaModels.Providers;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Mappings.Annotation
+namespace Untech.SharePoint.Mappings.Annotation
 {
 	internal class AnnotatedListPart : IMetaListProvider
 	{

--- a/Src/Untech.SharePoint.Common/Mappings/Annotation/AnnotatedMappingSource.cs
+++ b/Src/Untech.SharePoint.Common/Mappings/Annotation/AnnotatedMappingSource.cs
@@ -1,8 +1,8 @@
 ﻿using System.Reflection;
-using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.MetaModels;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.MetaModels;
 
-namespace Untech.SharePoint.Common.Mappings.Annotation
+namespace Untech.SharePoint.Mappings.Annotation
 {
 	internal sealed class AnnotatedMappingSource<TContext> : MappingSource<TContext>
 		where TContext : ISpContext

--- a/Src/Untech.SharePoint.Common/Mappings/Annotation/InvalidAnnotationException.cs
+++ b/Src/Untech.SharePoint.Common/Mappings/Annotation/InvalidAnnotationException.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Untech.SharePoint.Common.Mappings.Annotation
+namespace Untech.SharePoint.Mappings.Annotation
 {
 	/// <summary>
 	/// Represents errors that occurs due to invalid or incomplete annotation. 

--- a/Src/Untech.SharePoint.Common/Mappings/Annotation/SPFieldAttribute.cs
+++ b/Src/Untech.SharePoint.Common/Mappings/Annotation/SPFieldAttribute.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Converters;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Converters;
 
-namespace Untech.SharePoint.Common.Mappings.Annotation
+namespace Untech.SharePoint.Mappings.Annotation
 {
 	/// <summary>
 	/// When applied to property or field, specifies member that should be mapped to existing SP Field.

--- a/Src/Untech.SharePoint.Common/Mappings/Annotation/SpContentTypeAttribute.cs
+++ b/Src/Untech.SharePoint.Common/Mappings/Annotation/SpContentTypeAttribute.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using Untech.SharePoint.Common.CodeAnnotations;
+using Untech.SharePoint.CodeAnnotations;
 
-namespace Untech.SharePoint.Common.Mappings.Annotation
+namespace Untech.SharePoint.Mappings.Annotation
 {
 	/// <summary>
 	/// Class attribute that used for describing SP ContentType.

--- a/Src/Untech.SharePoint.Common/Mappings/Annotation/SpFieldRemovedAttribute.cs
+++ b/Src/Untech.SharePoint.Common/Mappings/Annotation/SpFieldRemovedAttribute.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using Untech.SharePoint.Common.CodeAnnotations;
+using Untech.SharePoint.CodeAnnotations;
 
-namespace Untech.SharePoint.Common.Mappings.Annotation
+namespace Untech.SharePoint.Mappings.Annotation
 {
 	/// <summary>
 	/// Property or field attribute that specifies field that was in SP ContentType but it is currently removed.

--- a/Src/Untech.SharePoint.Common/Mappings/Annotation/SpListAttribute.cs
+++ b/Src/Untech.SharePoint.Common/Mappings/Annotation/SpListAttribute.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Mappings.Annotation
+namespace Untech.SharePoint.Mappings.Annotation
 {
 	/// <summary>
 	/// When applied to property, specifies member that should be mapped to SP list.

--- a/Src/Untech.SharePoint.Common/Mappings/ClassLike/ContentTypeMap.cs
+++ b/Src/Untech.SharePoint.Common/Mappings/ClassLike/ContentTypeMap.cs
@@ -3,14 +3,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.Extensions;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.MetaModels.Providers;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.Extensions;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.MetaModels.Providers;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Mappings.ClassLike
+namespace Untech.SharePoint.Mappings.ClassLike
 {
 	/// <summary>
 	/// Represents provider of <see cref="MetaContentType"/> that allows to configure content type mapping in fluent way.

--- a/Src/Untech.SharePoint.Common/Mappings/ClassLike/ContextMap.cs
+++ b/Src/Untech.SharePoint.Common/Mappings/ClassLike/ContextMap.cs
@@ -2,13 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.MetaModels.Providers;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.MetaModels.Providers;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Mappings.ClassLike
+namespace Untech.SharePoint.Mappings.ClassLike
 {
 	/// <summary>
 	/// Represents provider of <see cref="MetaContext"/> that allows to configure mappings of all defined lists in fluent way.

--- a/Src/Untech.SharePoint.Common/Mappings/ClassLike/EntityContentTypeMap.cs
+++ b/Src/Untech.SharePoint.Common/Mappings/ClassLike/EntityContentTypeMap.cs
@@ -1,6 +1,6 @@
-using Untech.SharePoint.Common.Models;
+using Untech.SharePoint.Models;
 
-namespace Untech.SharePoint.Common.Mappings.ClassLike
+namespace Untech.SharePoint.Mappings.ClassLike
 {
 	/// <summary>
 	/// Represents base <see cref="ContentTypeMap{TEntity}"/> for types derived from <see cref="Entity"/>.

--- a/Src/Untech.SharePoint.Common/Mappings/ClassLike/FieldPart.cs
+++ b/Src/Untech.SharePoint.Common/Mappings/ClassLike/FieldPart.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Reflection;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Converters;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.MetaModels.Providers;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Converters;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.MetaModels.Providers;
 
-namespace Untech.SharePoint.Common.Mappings.ClassLike
+namespace Untech.SharePoint.Mappings.ClassLike
 {
 	/// <summary>
 	/// Represents provider of <see cref="MetaField"/> that allows to configure field mapping in fluent way.

--- a/Src/Untech.SharePoint.Common/Mappings/ClassLike/ListPart.cs
+++ b/Src/Untech.SharePoint.Common/Mappings/ClassLike/ListPart.cs
@@ -3,15 +3,15 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.Extensions;
-using Untech.SharePoint.Common.Mappings.Annotation;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.MetaModels.Providers;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.Extensions;
+using Untech.SharePoint.Mappings.Annotation;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.MetaModels.Providers;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.Mappings.ClassLike
+namespace Untech.SharePoint.Mappings.ClassLike
 {
 	/// <summary>
 	/// Represents provider of <see cref="MetaList"/> that allows to configure list mapping in fluent way.

--- a/Src/Untech.SharePoint.Common/Mappings/ClassLike/MappingSource.cs
+++ b/Src/Untech.SharePoint.Common/Mappings/ClassLike/MappingSource.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Reflection;
-using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.MetaModels.Providers;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.MetaModels.Providers;
 
-namespace Untech.SharePoint.Common.Mappings.ClassLike
+namespace Untech.SharePoint.Mappings.ClassLike
 {
 	internal class ClassLikeMappingSource<TContext> : MappingSource<TContext>
 		where TContext : ISpContext

--- a/Src/Untech.SharePoint.Common/Mappings/IListUrlResolver.cs
+++ b/Src/Untech.SharePoint.Common/Mappings/IListUrlResolver.cs
@@ -1,6 +1,6 @@
 ﻿using System.Reflection;
 
-namespace Untech.SharePoint.Common.Mappings
+namespace Untech.SharePoint.Mappings
 {
 	/// <summary>
 	/// Represents interface of object that can resolve list URL by context member.

--- a/Src/Untech.SharePoint.Common/Mappings/IMappingSource.cs
+++ b/Src/Untech.SharePoint.Common/Mappings/IMappingSource.cs
@@ -1,9 +1,9 @@
 ﻿using System;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.MetaModels.Providers;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.MetaModels.Providers;
 
-namespace Untech.SharePoint.Common.Mappings
+namespace Untech.SharePoint.Mappings
 {
 	/// <summary>
 	/// Represents interface that can create <see cref="MetaContext"/> and resolve list title for the specified member of this context.

--- a/Src/Untech.SharePoint.Common/Mappings/IMappingSourceResolver.cs
+++ b/Src/Untech.SharePoint.Common/Mappings/IMappingSourceResolver.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using Untech.SharePoint.Common.CodeAnnotations;
+using Untech.SharePoint.CodeAnnotations;
 
-namespace Untech.SharePoint.Common.Mappings
+namespace Untech.SharePoint.Mappings
 {
 	/// <summary>
 	/// Exposes Resolve method that will return <see cref="IMappingSource"/> for the specified context type.

--- a/Src/Untech.SharePoint.Common/Mappings/MappingSource.cs
+++ b/Src/Untech.SharePoint.Common/Mappings/MappingSource.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Reflection;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.MetaModels;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.MetaModels;
 
-namespace Untech.SharePoint.Common.Mappings
+namespace Untech.SharePoint.Mappings
 {
 	/// <summary>
 	/// Represents class that can create <see cref="MetaContext"/> and resolve list title for the specified member of this context.

--- a/Src/Untech.SharePoint.Common/Mappings/MappingSourceContainer.cs
+++ b/Src/Untech.SharePoint.Common/Mappings/MappingSourceContainer.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using Untech.SharePoint.Common.Collections;
+using Untech.SharePoint.Collections;
 
-namespace Untech.SharePoint.Common.Mappings
+namespace Untech.SharePoint.Mappings
 {
 	/// <summary>
 	/// Represents a collection of the context types and associated <see cref="IMappingSource"/>.

--- a/Src/Untech.SharePoint.Common/Mappings/Mappings.cs
+++ b/Src/Untech.SharePoint.Common/Mappings/Mappings.cs
@@ -1,8 +1,8 @@
-﻿using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.Mappings.Annotation;
-using Untech.SharePoint.Common.Mappings.ClassLike;
+﻿using Untech.SharePoint.Data;
+using Untech.SharePoint.Mappings.Annotation;
+using Untech.SharePoint.Mappings.ClassLike;
 
-namespace Untech.SharePoint.Common.Mappings
+namespace Untech.SharePoint.Mappings
 {
 	/// <summary>
 	/// Represents class that provides a set of methods that returns <see cref="MappingSource{TContext}"/>

--- a/Src/Untech.SharePoint.Common/Mappings/Rules.cs
+++ b/Src/Untech.SharePoint.Common/Mappings/Rules.cs
@@ -1,8 +1,8 @@
 ﻿using System.Reflection;
-using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.Mappings.Annotation;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.Mappings.Annotation;
 
-namespace Untech.SharePoint.Common.Mappings
+namespace Untech.SharePoint.Mappings
 {
 	internal static class Rules
 	{

--- a/Src/Untech.SharePoint.Common/MetaModels/BaseMetaModel.cs
+++ b/Src/Untech.SharePoint.Common/MetaModels/BaseMetaModel.cs
@@ -1,10 +1,10 @@
 ﻿using System;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Collections;
-using Untech.SharePoint.Common.MetaModels.Visitors;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Collections;
+using Untech.SharePoint.MetaModels.Visitors;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.MetaModels
+namespace Untech.SharePoint.MetaModels
 {
 	/// <summary>
 	/// Represent base meta model class that implements <see cref="IMetaModel"/>

--- a/Src/Untech.SharePoint.Common/MetaModels/Collections/MetaContentTypeCollection.cs
+++ b/Src/Untech.SharePoint.Common/MetaModels/Collections/MetaContentTypeCollection.cs
@@ -2,10 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.MetaModels.Collections
+namespace Untech.SharePoint.MetaModels.Collections
 {
 	/// <summary>
 	/// Represents collection of <see cref="MetaContentType"/> with fast access by <see cref="MetaContentType.EntityType"/>.

--- a/Src/Untech.SharePoint.Common/MetaModels/Collections/MetaFieldCollection.cs
+++ b/Src/Untech.SharePoint.Common/MetaModels/Collections/MetaFieldCollection.cs
@@ -2,10 +2,10 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.MetaModels.Collections
+namespace Untech.SharePoint.MetaModels.Collections
 {
 	/// <summary>
 	/// Represents collection of <see cref="MetaField"/> with fast access by <see cref="MetaField.MemberName"/>.

--- a/Src/Untech.SharePoint.Common/MetaModels/Collections/MetaListCollection.cs
+++ b/Src/Untech.SharePoint.Common/MetaModels/Collections/MetaListCollection.cs
@@ -2,10 +2,10 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.MetaModels.Collections
+namespace Untech.SharePoint.MetaModels.Collections
 {
 	/// <summary>
 	/// Represents collection of <see cref="MetaList"/> with fast access by <see cref="MetaList.Url"/>.

--- a/Src/Untech.SharePoint.Common/MetaModels/IMetaModel.cs
+++ b/Src/Untech.SharePoint.Common/MetaModels/IMetaModel.cs
@@ -1,7 +1,7 @@
-﻿using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.MetaModels.Visitors;
+﻿using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.MetaModels.Visitors;
 
-namespace Untech.SharePoint.Common.MetaModels
+namespace Untech.SharePoint.MetaModels
 {
 	/// <summary>
 	/// Represents base meta model interface.

--- a/Src/Untech.SharePoint.Common/MetaModels/MetaContentType.cs
+++ b/Src/Untech.SharePoint.Common/MetaModels/MetaContentType.cs
@@ -2,13 +2,13 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.MetaModels.Collections;
-using Untech.SharePoint.Common.MetaModels.Providers;
-using Untech.SharePoint.Common.MetaModels.Visitors;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.MetaModels.Collections;
+using Untech.SharePoint.MetaModels.Providers;
+using Untech.SharePoint.MetaModels.Visitors;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.MetaModels
+namespace Untech.SharePoint.MetaModels
 {
 	/// <summary>
 	/// Represents MetaData for SP ContentType

--- a/Src/Untech.SharePoint.Common/MetaModels/MetaContext.cs
+++ b/Src/Untech.SharePoint.Common/MetaModels/MetaContext.cs
@@ -2,14 +2,14 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.MetaModels.Collections;
-using Untech.SharePoint.Common.MetaModels.Providers;
-using Untech.SharePoint.Common.MetaModels.Visitors;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.MetaModels.Collections;
+using Untech.SharePoint.MetaModels.Providers;
+using Untech.SharePoint.MetaModels.Visitors;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.MetaModels
+namespace Untech.SharePoint.MetaModels
 {
 	/// <summary>
 	/// Represents MetaData of <see cref="ISpContext"/>

--- a/Src/Untech.SharePoint.Common/MetaModels/MetaField.cs
+++ b/Src/Untech.SharePoint.Common/MetaModels/MetaField.cs
@@ -1,13 +1,13 @@
 ﻿using System;
 using System.Reflection;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Converters;
-using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.Extensions;
-using Untech.SharePoint.Common.MetaModels.Visitors;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Converters;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.Extensions;
+using Untech.SharePoint.MetaModels.Visitors;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.MetaModels
+namespace Untech.SharePoint.MetaModels
 {
 	/// <summary>
 	/// Represents MetaData for SP Field.

--- a/Src/Untech.SharePoint.Common/MetaModels/MetaList.cs
+++ b/Src/Untech.SharePoint.Common/MetaModels/MetaList.cs
@@ -2,14 +2,14 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.MetaModels.Collections;
-using Untech.SharePoint.Common.MetaModels.Providers;
-using Untech.SharePoint.Common.MetaModels.Visitors;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.MetaModels.Collections;
+using Untech.SharePoint.MetaModels.Providers;
+using Untech.SharePoint.MetaModels.Visitors;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.MetaModels
+namespace Untech.SharePoint.MetaModels
 {
 	/// <summary>
 	/// Represents MetaData for SP List

--- a/Src/Untech.SharePoint.Common/MetaModels/MetaModelExtensions.cs
+++ b/Src/Untech.SharePoint.Common/MetaModels/MetaModelExtensions.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Linq;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Data.Mapper;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Data.Mapper;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.MetaModels
+namespace Untech.SharePoint.MetaModels
 {
 	/// <summary>
 	/// Provides a set of static methods for easy work with <see cref="IMetaModel"/> additional properties.

--- a/Src/Untech.SharePoint.Common/MetaModels/Providers/IMetaContentTypeProvider.cs
+++ b/Src/Untech.SharePoint.Common/MetaModels/Providers/IMetaContentTypeProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace Untech.SharePoint.Common.MetaModels.Providers
+﻿namespace Untech.SharePoint.MetaModels.Providers
 {
 	/// <summary>
 	/// Represents interface of <see cref="MetaContentType"/> provider.

--- a/Src/Untech.SharePoint.Common/MetaModels/Providers/IMetaContextProvider.cs
+++ b/Src/Untech.SharePoint.Common/MetaModels/Providers/IMetaContextProvider.cs
@@ -1,4 +1,4 @@
-namespace Untech.SharePoint.Common.MetaModels.Providers
+namespace Untech.SharePoint.MetaModels.Providers
 {
 	/// <summary>
 	/// Represents interface of <see cref="MetaContext"/> provider.

--- a/Src/Untech.SharePoint.Common/MetaModels/Providers/IMetaFieldProvider.cs
+++ b/Src/Untech.SharePoint.Common/MetaModels/Providers/IMetaFieldProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace Untech.SharePoint.Common.MetaModels.Providers
+﻿namespace Untech.SharePoint.MetaModels.Providers
 {
 	/// <summary>
 	/// Represents interface of <see cref="MetaField"/> provider.

--- a/Src/Untech.SharePoint.Common/MetaModels/Providers/IMetaListProvider.cs
+++ b/Src/Untech.SharePoint.Common/MetaModels/Providers/IMetaListProvider.cs
@@ -1,4 +1,4 @@
-﻿namespace Untech.SharePoint.Common.MetaModels.Providers
+﻿namespace Untech.SharePoint.MetaModels.Providers
 {
 	/// <summary>
 	/// Represents interface of <see cref="MetaList"/> provider.

--- a/Src/Untech.SharePoint.Common/MetaModels/SiteRelativeUrlComparer.cs
+++ b/Src/Untech.SharePoint.Common/MetaModels/SiteRelativeUrlComparer.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Common.MetaModels
+namespace Untech.SharePoint.MetaModels
 {
 	/// <summary>
 	/// Represents a string comparison operations that allows to compare site-relative URL ignoring case.

--- a/Src/Untech.SharePoint.Common/MetaModels/Visitors/BaseMetaModelVisitor.cs
+++ b/Src/Untech.SharePoint.Common/MetaModels/Visitors/BaseMetaModelVisitor.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace Untech.SharePoint.Common.MetaModels.Visitors
+namespace Untech.SharePoint.MetaModels.Visitors
 {
 	/// <summary>
 	/// Represents base meta models visitor.

--- a/Src/Untech.SharePoint.Common/MetaModels/Visitors/IMetaModelVisitor.cs
+++ b/Src/Untech.SharePoint.Common/MetaModels/Visitors/IMetaModelVisitor.cs
@@ -1,4 +1,4 @@
-﻿namespace Untech.SharePoint.Common.MetaModels.Visitors
+﻿namespace Untech.SharePoint.MetaModels.Visitors
 {
 	/// <summary>
 	/// Represents meta model visitor interface.

--- a/Src/Untech.SharePoint.Common/Models/Entity.cs
+++ b/Src/Untech.SharePoint.Common/Models/Entity.cs
@@ -2,10 +2,10 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Mappings.Annotation;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Mappings.Annotation;
 
-namespace Untech.SharePoint.Common.Models
+namespace Untech.SharePoint.Models
 {
 	/// <summary>
 	/// Represents base SP content type entity.

--- a/Src/Untech.SharePoint.Common/Models/GeoInfo.cs
+++ b/Src/Untech.SharePoint.Common/Models/GeoInfo.cs
@@ -1,8 +1,8 @@
 ﻿using System.Runtime.Serialization;
 using Newtonsoft.Json;
-using Untech.SharePoint.Common.CodeAnnotations;
+using Untech.SharePoint.CodeAnnotations;
 
-namespace Untech.SharePoint.Common.Models
+namespace Untech.SharePoint.Models
 {
 	/// <summary>
 	/// Represents Geo info data.

--- a/Src/Untech.SharePoint.Common/Models/ObjectReference.cs
+++ b/Src/Untech.SharePoint.Common/Models/ObjectReference.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;
-using Untech.SharePoint.Common.CodeAnnotations;
+using Untech.SharePoint.CodeAnnotations;
 
-namespace Untech.SharePoint.Common.Models
+namespace Untech.SharePoint.Models
 {
 	/// <summary>
 	/// Represents lookup field value

--- a/Src/Untech.SharePoint.Common/Models/UrlInfo.cs
+++ b/Src/Untech.SharePoint.Common/Models/UrlInfo.cs
@@ -1,8 +1,8 @@
 ﻿using System.Runtime.Serialization;
 using Newtonsoft.Json;
-using Untech.SharePoint.Common.CodeAnnotations;
+using Untech.SharePoint.CodeAnnotations;
 
-namespace Untech.SharePoint.Common.Models
+namespace Untech.SharePoint.Models
 {
 	/// <summary>
 	/// Represents URL info.

--- a/Src/Untech.SharePoint.Common/Models/UserInfo.cs
+++ b/Src/Untech.SharePoint.Common/Models/UserInfo.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Runtime.Serialization;
 using Newtonsoft.Json;
-using Untech.SharePoint.Common.CodeAnnotations;
+using Untech.SharePoint.CodeAnnotations;
 
-namespace Untech.SharePoint.Common.Models
+namespace Untech.SharePoint.Models
 {
 	/// <summary>
 	/// Represents user info

--- a/Src/Untech.SharePoint.Common/Tags.cs
+++ b/Src/Untech.SharePoint.Common/Tags.cs
@@ -1,6 +1,6 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 
-namespace Untech.SharePoint.Common
+namespace Untech.SharePoint
 {
 	[SuppressMessage("ReSharper", "UnusedMember.Global")]
 	internal static class Tags

--- a/Src/Untech.SharePoint.Common/Untech.SharePoint.Common.csproj
+++ b/Src/Untech.SharePoint.Common/Untech.SharePoint.Common.csproj
@@ -17,6 +17,7 @@
     <PackageTags>SharePoint Data ORM</PackageTags>
     <RepositoryUrl>https://github.com/Happi-cat/Untech.SharePoint.git</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>
+    <RootNamespace>Untech.SharePoint</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="10.0.2" />

--- a/Src/Untech.SharePoint.Common/Utils/Error.cs
+++ b/Src/Untech.SharePoint.Common/Utils/Error.cs
@@ -2,12 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using Untech.SharePoint.Common.Converters;
-using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.Extensions;
-using Untech.SharePoint.Common.MetaModels;
+using Untech.SharePoint.Converters;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.Extensions;
+using Untech.SharePoint.MetaModels;
 
-namespace Untech.SharePoint.Common.Utils
+namespace Untech.SharePoint.Utils
 {
 	internal static class Error
 	{

--- a/Src/Untech.SharePoint.Common/Utils/Guard.cs
+++ b/Src/Untech.SharePoint.Common/Utils/Guard.cs
@@ -1,10 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Extensions;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Extensions;
 
-namespace Untech.SharePoint.Common.Utils
+namespace Untech.SharePoint.Utils
 {
 	/// <summary>
 	/// Provides a set of static methods for arguments validation.

--- a/Src/Untech.SharePoint.Common/Utils/Reflection/InstanceCreationUtility.cs
+++ b/Src/Untech.SharePoint.Common/Utils/Reflection/InstanceCreationUtility.cs
@@ -2,9 +2,9 @@
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
-using Untech.SharePoint.Common.CodeAnnotations;
+using Untech.SharePoint.CodeAnnotations;
 
-namespace Untech.SharePoint.Common.Utils.Reflection
+namespace Untech.SharePoint.Utils.Reflection
 {
 	[UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
 	internal static class InstanceCreationUtility

--- a/Src/Untech.SharePoint.Common/Utils/Reflection/MemberAccessUtility.cs
+++ b/Src/Untech.SharePoint.Common/Utils/Reflection/MemberAccessUtility.cs
@@ -1,12 +1,12 @@
 ﻿using System;
 using System.Linq.Expressions;
 using System.Reflection;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Extensions;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Extensions;
 using Getter = System.Func<object, object>;
 using Setter = System.Action<object, object>;
 
-namespace Untech.SharePoint.Common.Utils.Reflection
+namespace Untech.SharePoint.Utils.Reflection
 {
 	[UsedImplicitly(ImplicitUseTargetFlags.WithMembers)]
 	internal static class MemberAccessUtility

--- a/Src/Untech.SharePoint.Common/Utils/Reflection/ReflectionError.cs
+++ b/Src/Untech.SharePoint.Common/Utils/Reflection/ReflectionError.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Reflection;
-using Untech.SharePoint.Common.Extensions;
+using Untech.SharePoint.Extensions;
 
-namespace Untech.SharePoint.Common.Utils.Reflection
+namespace Untech.SharePoint.Utils.Reflection
 {
 	internal static class ReflectionError
 	{

--- a/Src/Untech.SharePoint.Common/Utils/Singleton.cs
+++ b/Src/Untech.SharePoint.Common/Utils/Singleton.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using Untech.SharePoint.Common.CodeAnnotations;
+using Untech.SharePoint.CodeAnnotations;
 
-namespace Untech.SharePoint.Common.Utils
+namespace Untech.SharePoint.Utils
 {
 	/// <summary>
 	/// Represents container for instance singleton

--- a/Src/Untech.SharePoint.Server.Test/Converters/BuiltIn/ContentTypeIdFieldConverterTest.cs
+++ b/Src/Untech.SharePoint.Server.Test/Converters/BuiltIn/ContentTypeIdFieldConverterTest.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Untech.SharePoint.Common.Converters;
+using Untech.SharePoint.Converters;
 
 namespace Untech.SharePoint.Server.Converters.BuiltIn
 {

--- a/Src/Untech.SharePoint.Server.Test/Converters/BuiltIn/UrlFieldConverterTest.cs
+++ b/Src/Untech.SharePoint.Server.Test/Converters/BuiltIn/UrlFieldConverterTest.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using Microsoft.SharePoint;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Untech.SharePoint.Common.Converters;
-using Untech.SharePoint.Common.Models;
+using Untech.SharePoint.Converters;
+using Untech.SharePoint.Models;
 
 namespace Untech.SharePoint.Server.Converters.BuiltIn
 {

--- a/Src/Untech.SharePoint.Server.Test/Data/BasicOperationsTest.cs
+++ b/Src/Untech.SharePoint.Server.Test/Data/BasicOperationsTest.cs
@@ -1,8 +1,9 @@
 ﻿using System.Linq;
 using Microsoft.SharePoint;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Untech.SharePoint.Common.Spec;
-using Untech.SharePoint.Common.Spec.Models;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.Spec;
+using Untech.SharePoint.Spec.Models;
 
 namespace Untech.SharePoint.Server.Data
 {

--- a/Src/Untech.SharePoint.Server.Test/Data/Bootstrap.cs
+++ b/Src/Untech.SharePoint.Server.Test/Data/Bootstrap.cs
@@ -1,7 +1,6 @@
-﻿using Untech.SharePoint.Common.Configuration;
-using Untech.SharePoint.Common.Spec.Models;
-using Untech.SharePoint.Common.Utils;
-using Untech.SharePoint.Server.Configuration;
+﻿using Untech.SharePoint.Configuration;
+using Untech.SharePoint.Spec.Models;
+using Untech.SharePoint.Utils;
 
 namespace Untech.SharePoint.Server.Data
 {

--- a/Src/Untech.SharePoint.Server.Test/Data/QueryablePerfTest.cs
+++ b/Src/Untech.SharePoint.Server.Test/Data/QueryablePerfTest.cs
@@ -1,8 +1,9 @@
 ﻿using Microsoft.SharePoint;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Untech.SharePoint.Common.Spec;
-using Untech.SharePoint.Common.Spec.Models;
-using Untech.SharePoint.Common.TestTools.QueryTests;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.Spec;
+using Untech.SharePoint.Spec.Models;
+using Untech.SharePoint.TestTools.QueryTests;
 
 namespace Untech.SharePoint.Server.Data
 {

--- a/Src/Untech.SharePoint.Server.Test/Data/QueryableTest.cs
+++ b/Src/Untech.SharePoint.Server.Test/Data/QueryableTest.cs
@@ -1,7 +1,8 @@
 ﻿using Microsoft.SharePoint;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Untech.SharePoint.Common.Spec;
-using Untech.SharePoint.Common.Spec.Models;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.Spec;
+using Untech.SharePoint.Spec.Models;
 
 namespace Untech.SharePoint.Server.Data
 {

--- a/Src/Untech.SharePoint.Server.Test/Data/ServerTestQueryExecutor.cs
+++ b/Src/Untech.SharePoint.Server.Test/Data/ServerTestQueryExecutor.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Microsoft.SharePoint;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.TestTools.QueryTests;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.TestTools.QueryTests;
 
 namespace Untech.SharePoint.Server.Data
 {

--- a/Src/Untech.SharePoint.Server.Test/DataGenerator.cs
+++ b/Src/Untech.SharePoint.Server.Test/DataGenerator.cs
@@ -1,14 +1,15 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
 using Microsoft.SharePoint;
-using Untech.SharePoint.Common.Models;
-using Untech.SharePoint.Common.Spec.Models;
-using Untech.SharePoint.Common.TestTools.DataGenerators;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.Models;
 using Untech.SharePoint.Server.Data;
+using Untech.SharePoint.Spec.Models;
+using Untech.SharePoint.TestTools.DataGenerators;
 
 namespace Untech.SharePoint.Server
 {
-	public class DataGenerator
+	public static class DataGenerator
 	{
 		public static void Generate()
 		{

--- a/Src/Untech.SharePoint.Server/(Configuration)/ServerConfig.cs
+++ b/Src/Untech.SharePoint.Server/(Configuration)/ServerConfig.cs
@@ -1,21 +1,19 @@
-﻿using Untech.SharePoint.Common.Configuration;
-
-namespace Untech.SharePoint.Client.Configuration
+﻿namespace Untech.SharePoint.Configuration
 {
 	/// <summary>
 	/// Provides static method for starting <see cref="ConfigBuilder"/> configuration.
 	/// </summary>
-	public static class ClientConfig
+	public static class ServerConfig
 	{
 		/// <summary>
 		/// Begins configuration of the <see cref="ConfigBuilder"/> instance.
 		/// </summary>
-		/// <returns>Config builder with registered built-in field converters from <see cref="Common"/> and <see cref="Client"/> assemblies.</returns>
+		/// <returns>Config builder with registered built-in field converters from <see cref="Common"/> and <see cref="Server"/> assemblies.</returns>
 		public static ConfigBuilder Begin()
 		{
 			return (new ConfigBuilder())
 				.RegisterConverters(n => n.AddFromAssembly(typeof(ConfigBuilder).Assembly))
-				.RegisterConverters(n => n.AddFromAssembly(typeof(ClientConfig).Assembly));
+				.RegisterConverters(n => n.AddFromAssembly(typeof(ServerConfig).Assembly));
 		}
 	}
 }

--- a/Src/Untech.SharePoint.Server/(Data)/SpServerCommonService.cs
+++ b/Src/Untech.SharePoint.Server/(Data)/SpServerCommonService.cs
@@ -1,15 +1,15 @@
 ﻿using System.Collections.Generic;
 using Microsoft.SharePoint;
-using Untech.SharePoint.Common.Configuration;
-using Untech.SharePoint.Common.Converters;
-using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.MetaModels.Visitors;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Configuration;
+using Untech.SharePoint.Converters;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.MetaModels.Visitors;
+using Untech.SharePoint.Server.Data;
 using Untech.SharePoint.Server.Data.Mapper;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Server.Data
+namespace Untech.SharePoint.Data
 {
 	/// <summary>
 	/// Represents service that use SSOM (i.e. SharePoint Server Object Model) and can be used inside <see cref="SpContext{TContext}"/>.

--- a/Src/Untech.SharePoint.Server/(Data)/SpServerContext.cs
+++ b/Src/Untech.SharePoint.Server/(Data)/SpServerContext.cs
@@ -1,12 +1,11 @@
 ﻿using System;
 using System.Linq.Expressions;
 using Microsoft.SharePoint;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Configuration;
-using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Configuration;
+using Untech.SharePoint.Utils;
 
-namespace Untech.SharePoint.Server.Data
+namespace Untech.SharePoint.Data
 {
 	/// <summary>
 	/// Represents base data context class for SSOM.

--- a/Src/Untech.SharePoint.Server/Converters/BuiltIn/CalculatedFieldConverter.cs
+++ b/Src/Untech.SharePoint.Server/Converters/BuiltIn/CalculatedFieldConverter.cs
@@ -1,8 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
-using Untech.SharePoint.Common.Converters;
-using Untech.SharePoint.Common.MetaModels;
+using Untech.SharePoint.Converters;
+using Untech.SharePoint.MetaModels;
 
 namespace Untech.SharePoint.Server.Converters.BuiltIn
 {

--- a/Src/Untech.SharePoint.Server/Converters/BuiltIn/ContentTypeIdConverter.cs
+++ b/Src/Untech.SharePoint.Server/Converters/BuiltIn/ContentTypeIdConverter.cs
@@ -1,8 +1,8 @@
 ﻿using Microsoft.SharePoint;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Converters;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Converters;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.Utils;
 
 namespace Untech.SharePoint.Server.Converters.BuiltIn
 {

--- a/Src/Untech.SharePoint.Server/Converters/BuiltIn/GeolocationFieldConverter.cs
+++ b/Src/Untech.SharePoint.Server/Converters/BuiltIn/GeolocationFieldConverter.cs
@@ -1,10 +1,10 @@
 using System;
 using Microsoft.SharePoint;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Converters;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.Models;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Converters;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.Models;
+using Untech.SharePoint.Utils;
 
 namespace Untech.SharePoint.Server.Converters.BuiltIn
 {

--- a/Src/Untech.SharePoint.Server/Converters/BuiltIn/LookupFieldConverter.cs
+++ b/Src/Untech.SharePoint.Server/Converters/BuiltIn/LookupFieldConverter.cs
@@ -2,12 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.SharePoint;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Converters;
-using Untech.SharePoint.Common.Extensions;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.Models;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Converters;
+using Untech.SharePoint.Extensions;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.Models;
+using Untech.SharePoint.Utils;
 
 namespace Untech.SharePoint.Server.Converters.BuiltIn
 {
@@ -59,7 +59,7 @@ namespace Untech.SharePoint.Server.Converters.BuiltIn
 
 			var fieldValues = new SPFieldLookupValueCollection(value.ToString());
 			var lookupValues = fieldValues.Select(ConvertToObjRef).ToList();
-			if (!lookupValues.Any())
+			if (lookupValues.Count == 0)
 			{
 				return null;
 			}
@@ -80,7 +80,7 @@ namespace Untech.SharePoint.Server.Converters.BuiltIn
 			}
 
 			var lookupValues = ((IEnumerable<ObjectReference>)value).Distinct().ToList();
-			if (!lookupValues.Any())
+			if (lookupValues.Count == 0)
 			{
 				return null;
 			}
@@ -95,8 +95,7 @@ namespace Untech.SharePoint.Server.Converters.BuiltIn
 		{
 			if (value == null) return null;
 
-			var singleValue = value as ObjectReference;
-			if (singleValue != null)
+			if (value is ObjectReference singleValue)
 			{
 				return singleValue.Id.ToString();
 			}

--- a/Src/Untech.SharePoint.Server/Converters/BuiltIn/MultiChoiceFieldConverter.cs
+++ b/Src/Untech.SharePoint.Server/Converters/BuiltIn/MultiChoiceFieldConverter.cs
@@ -2,11 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.SharePoint;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Converters;
-using Untech.SharePoint.Common.Extensions;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Converters;
+using Untech.SharePoint.Extensions;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.Utils;
 
 namespace Untech.SharePoint.Server.Converters.BuiltIn
 {
@@ -60,14 +60,13 @@ namespace Untech.SharePoint.Server.Converters.BuiltIn
 		{
 			if (value == null) return "";
 
-			var singleValue = value as string;
-			if (singleValue != null)
+			if (value is string singleValue)
 			{
 				return string.Format(";#{0};#", singleValue);
 			}
 
 			var multiValue = ((IEnumerable<string>)value).Distinct().ToList();
-			return multiValue.Any() ? string.Format(";#{0};#", multiValue.JoinToString(";#")) : "";
+			return multiValue.Count > 0 ? string.Format(";#{0};#", multiValue.JoinToString(";#")) : "";
 		}
 	}
 }

--- a/Src/Untech.SharePoint.Server/Converters/BuiltIn/UrlFieldConverter.cs
+++ b/Src/Untech.SharePoint.Server/Converters/BuiltIn/UrlFieldConverter.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
 using Microsoft.SharePoint;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Converters;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.Models;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Converters;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.Models;
 
 namespace Untech.SharePoint.Server.Converters.BuiltIn
 {
@@ -14,8 +14,8 @@ namespace Untech.SharePoint.Server.Converters.BuiltIn
 	{
 		private static readonly IReadOnlyDictionary<Type, Func<IFieldConverter>> s_typeConverters = new Dictionary<Type, Func<IFieldConverter>>
 		{
-			{typeof(string), () => new StringTypeConverter()},
-			{typeof(UrlInfo), () => new UrlInfoTypeConverter()},
+			[typeof(string)] = () => new StringTypeConverter(),
+			[typeof(UrlInfo)] = () => new UrlInfoTypeConverter(),
 		};
 
 		public override void Initialize(MetaField field)
@@ -44,7 +44,7 @@ namespace Untech.SharePoint.Server.Converters.BuiltIn
 
 			public object ToSpValue(object value)
 			{
-				return value != null ? value.ToString() : null;
+				return value?.ToString();
 			}
 
 			public string ToCamlValue(object value)

--- a/Src/Untech.SharePoint.Server/Converters/BuiltIn/UserFieldConverter.cs
+++ b/Src/Untech.SharePoint.Server/Converters/BuiltIn/UserFieldConverter.cs
@@ -2,13 +2,13 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.SharePoint;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Converters;
-using Untech.SharePoint.Common.Extensions;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.Models;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Converters;
+using Untech.SharePoint.Extensions;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.Models;
 using Untech.SharePoint.Server.Data;
+using Untech.SharePoint.Utils;
 
 namespace Untech.SharePoint.Server.Converters.BuiltIn
 {
@@ -61,7 +61,7 @@ namespace Untech.SharePoint.Server.Converters.BuiltIn
 			var fieldValues = new SPFieldUserValueCollection(_web, value.ToString());
 			var userValues = fieldValues.Select(ConvertToUserInfo).ToList();
 
-			if (!userValues.Any())
+			if (userValues.Count == 0)
 			{
 				return null;
 			}
@@ -81,7 +81,7 @@ namespace Untech.SharePoint.Server.Converters.BuiltIn
 			}
 
 			var userValues = ((IEnumerable<UserInfo>)value).Distinct().ToList();
-			if (!userValues.Any())
+			if (userValues.Count == 0)
 			{
 				return null;
 			}
@@ -96,8 +96,7 @@ namespace Untech.SharePoint.Server.Converters.BuiltIn
 		{
 			if (value == null) return null;
 
-			var singleValue = value as UserInfo;
-			if (singleValue != null)
+			if (value is UserInfo singleValue)
 			{
 				return singleValue.Id.ToString();
 			}

--- a/Src/Untech.SharePoint.Server/Data/BatchBuilder.cs
+++ b/Src/Untech.SharePoint.Server/Data/BatchBuilder.cs
@@ -3,9 +3,8 @@ using System.IO;
 using System.Linq;
 using System.Security;
 using System.Text;
-using System.Xml;
 using Microsoft.SharePoint;
-using Untech.SharePoint.Common.Extensions;
+using Untech.SharePoint.Extensions;
 
 namespace Untech.SharePoint.Server.Data
 {

--- a/Src/Untech.SharePoint.Server/Data/Mapper/MapperInitializer.cs
+++ b/Src/Untech.SharePoint.Server/Data/Mapper/MapperInitializer.cs
@@ -1,7 +1,7 @@
 using Microsoft.SharePoint;
-using Untech.SharePoint.Common.Data.Mapper;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.MetaModels.Visitors;
+using Untech.SharePoint.Data.Mapper;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.MetaModels.Visitors;
 
 namespace Untech.SharePoint.Server.Data.Mapper
 {

--- a/Src/Untech.SharePoint.Server/Data/Mapper/StoreAccessor.cs
+++ b/Src/Untech.SharePoint.Server/Data/Mapper/StoreAccessor.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.SharePoint;
-using Untech.SharePoint.Common.Data.Mapper;
-using Untech.SharePoint.Common.MetaModels;
+using Untech.SharePoint.Data.Mapper;
+using Untech.SharePoint.MetaModels;
 
 namespace Untech.SharePoint.Server.Data.Mapper
 {

--- a/Src/Untech.SharePoint.Server/Data/Mapper/TypeMapper.cs
+++ b/Src/Untech.SharePoint.Server/Data/Mapper/TypeMapper.cs
@@ -1,6 +1,6 @@
 using Microsoft.SharePoint;
-using Untech.SharePoint.Common.Data.Mapper;
-using Untech.SharePoint.Common.MetaModels;
+using Untech.SharePoint.Data.Mapper;
+using Untech.SharePoint.MetaModels;
 
 namespace Untech.SharePoint.Server.Data.Mapper
 {

--- a/Src/Untech.SharePoint.Server/Data/MetaFieldWebInitilizer.cs
+++ b/Src/Untech.SharePoint.Server/Data/MetaFieldWebInitilizer.cs
@@ -1,6 +1,6 @@
 ﻿using Microsoft.SharePoint;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.MetaModels.Visitors;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.MetaModels.Visitors;
 
 namespace Untech.SharePoint.Server.Data
 {

--- a/Src/Untech.SharePoint.Server/Data/MetaModelExtensions.cs
+++ b/Src/Untech.SharePoint.Server/Data/MetaModelExtensions.cs
@@ -1,7 +1,7 @@
 ﻿using Microsoft.SharePoint;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.Utils;
 
 namespace Untech.SharePoint.Server.Data
 {

--- a/Src/Untech.SharePoint.Server/Data/RuntimeInfoLoader.cs
+++ b/Src/Untech.SharePoint.Server/Data/RuntimeInfoLoader.cs
@@ -1,12 +1,11 @@
 ﻿using System;
-using System.IO;
 using System.Linq;
 using Microsoft.SharePoint;
-using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.MetaModels;
-using Untech.SharePoint.Common.MetaModels.Visitors;
-using Untech.SharePoint.Common.Utils;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.MetaModels;
+using Untech.SharePoint.MetaModels.Visitors;
 using Untech.SharePoint.Server.Extensions;
+using Untech.SharePoint.Utils;
 
 namespace Untech.SharePoint.Server.Data
 {

--- a/Src/Untech.SharePoint.Server/Data/SpListItemsProvider.cs
+++ b/Src/Untech.SharePoint.Server/Data/SpListItemsProvider.cs
@@ -2,9 +2,9 @@
 using System.Collections.Generic;
 using System.Linq;
 using Microsoft.SharePoint;
-using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.Data.Mapper;
-using Untech.SharePoint.Common.MetaModels;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.Data.Mapper;
+using Untech.SharePoint.MetaModels;
 using Untech.SharePoint.Server.Extensions;
 using Untech.SharePoint.Server.Utils;
 

--- a/Src/Untech.SharePoint.Server/Extensions/SPWebExtensions.cs
+++ b/Src/Untech.SharePoint.Server/Extensions/SPWebExtensions.cs
@@ -1,7 +1,5 @@
-﻿using System;
-using System.IO;
-using Microsoft.SharePoint;
-using Untech.SharePoint.Common.CodeAnnotations;
+﻿using Microsoft.SharePoint;
+using Untech.SharePoint.CodeAnnotations;
 
 namespace Untech.SharePoint.Server.Extensions
 {

--- a/src/Untech.SharePoint.Common.Test/TestTools/Comparers/EntityComparer.cs
+++ b/src/Untech.SharePoint.Common.Test/TestTools/Comparers/EntityComparer.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Untech.SharePoint.Common.Models;
+using Untech.SharePoint.Models;
 
-namespace Untech.SharePoint.Common.TestTools.Comparers
+namespace Untech.SharePoint.TestTools.Comparers
 {
 	public class EntityComparer : IEqualityComparer<Entity>, IEqualityComparer<IEnumerable<Entity>>
 	{

--- a/src/Untech.SharePoint.Common.Test/TestTools/Comparers/SequenceComparer.cs
+++ b/src/Untech.SharePoint.Common.Test/TestTools/Comparers/SequenceComparer.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Untech.SharePoint.Common.TestTools.Comparers
+namespace Untech.SharePoint.TestTools.Comparers
 {
 	public class SequenceComparer<T> : IEqualityComparer<IEnumerable<T>>
 	{

--- a/src/Untech.SharePoint.Common.Test/TestTools/DataGenerators/Generators.cs
+++ b/src/Untech.SharePoint.Common.Test/TestTools/DataGenerators/Generators.cs
@@ -1,10 +1,10 @@
-﻿using Untech.SharePoint.Common.Models;
-using Untech.SharePoint.Common.Spec.Models;
-using Untech.SharePoint.Common.TestTools.Generators;
-using Untech.SharePoint.Common.TestTools.Generators.Basic;
-using Untech.SharePoint.Common.TestTools.Generators.Custom;
+﻿using Untech.SharePoint.Models;
+using Untech.SharePoint.Spec.Models;
+using Untech.SharePoint.TestTools.Generators;
+using Untech.SharePoint.TestTools.Generators.Basic;
+using Untech.SharePoint.TestTools.Generators.Custom;
 
-namespace Untech.SharePoint.Common.TestTools.DataGenerators
+namespace Untech.SharePoint.TestTools.DataGenerators
 {
 	public static class Generators
 	{

--- a/src/Untech.SharePoint.Common.Test/TestTools/DataGenerators/ListTestDataGenerator.cs
+++ b/src/Untech.SharePoint.Common.Test/TestTools/DataGenerators/ListTestDataGenerator.cs
@@ -1,11 +1,11 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.TestTools.Generators;
-using Untech.SharePoint.Common.TestTools.Generators.Basic;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.TestTools.Generators;
+using Untech.SharePoint.TestTools.Generators.Basic;
 
-namespace Untech.SharePoint.Common.TestTools.DataGenerators
+namespace Untech.SharePoint.TestTools.DataGenerators
 {
 	public class ListTestDataGenerator<T>
 	{

--- a/src/Untech.SharePoint.Common.Test/TestTools/DataGenerators/TestDataGenerator.cs
+++ b/src/Untech.SharePoint.Common.Test/TestTools/DataGenerators/TestDataGenerator.cs
@@ -1,11 +1,11 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Untech.SharePoint.Common.Models;
-using Untech.SharePoint.Common.Spec.Models;
-using Untech.SharePoint.Common.TestTools.Generators;
-using Untech.SharePoint.Common.TestTools.Generators.Basic;
+using Untech.SharePoint.Models;
+using Untech.SharePoint.Spec.Models;
+using Untech.SharePoint.TestTools.Generators;
+using Untech.SharePoint.TestTools.Generators.Basic;
 
-namespace Untech.SharePoint.Common.TestTools.DataGenerators
+namespace Untech.SharePoint.TestTools.DataGenerators
 {
 	public class TestDataGenerator
 	{

--- a/src/Untech.SharePoint.Common.Test/TestTools/DataManagers/ListTestDataManager.cs
+++ b/src/Untech.SharePoint.Common.Test/TestTools/DataManagers/ListTestDataManager.cs
@@ -1,9 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Data;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Data;
 
-namespace Untech.SharePoint.Common.TestTools.DataManagers
+namespace Untech.SharePoint.TestTools.DataManagers
 {
 	public class ListTestDataManager<T>
 	{

--- a/src/Untech.SharePoint.Common.Test/TestTools/DataManagers/TestDataManager.cs
+++ b/src/Untech.SharePoint.Common.Test/TestTools/DataManagers/TestDataManager.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
-using Untech.SharePoint.Common.Spec.Models;
+using Untech.SharePoint.Spec.Models;
 
-namespace Untech.SharePoint.Common.TestTools.DataManagers
+namespace Untech.SharePoint.TestTools.DataManagers
 {
 	public class TestDataManager
 	{

--- a/src/Untech.SharePoint.Common.Test/TestTools/Generators/Basic/ArrayGenerationOptions.cs
+++ b/src/Untech.SharePoint.Common.Test/TestTools/Generators/Basic/ArrayGenerationOptions.cs
@@ -1,4 +1,4 @@
-namespace Untech.SharePoint.Common.TestTools.Generators.Basic
+namespace Untech.SharePoint.TestTools.Generators.Basic
 {
 	public enum ArrayGenerationOptions
 	{

--- a/src/Untech.SharePoint.Common.Test/TestTools/Generators/Basic/ArrayGenerator.cs
+++ b/src/Untech.SharePoint.Common.Test/TestTools/Generators/Basic/ArrayGenerator.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Generic;
 
-namespace Untech.SharePoint.Common.TestTools.Generators.Basic
+namespace Untech.SharePoint.TestTools.Generators.Basic
 {
 	public class ArrayGenerator<T> : BaseRandomGenerator, IValueGenerator<List<T>>, IValueGenerator<T[]>
 	{

--- a/src/Untech.SharePoint.Common.Test/TestTools/Generators/Basic/BaseRandomGenerator.cs
+++ b/src/Untech.SharePoint.Common.Test/TestTools/Generators/Basic/BaseRandomGenerator.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Untech.SharePoint.Common.TestTools.Generators.Basic
+namespace Untech.SharePoint.TestTools.Generators.Basic
 {
 	public class BaseRandomGenerator
 	{

--- a/src/Untech.SharePoint.Common.Test/TestTools/Generators/Basic/BoolRangeGenerator.cs
+++ b/src/Untech.SharePoint.Common.Test/TestTools/Generators/Basic/BoolRangeGenerator.cs
@@ -1,4 +1,4 @@
-﻿namespace Untech.SharePoint.Common.TestTools.Generators.Basic
+﻿namespace Untech.SharePoint.TestTools.Generators.Basic
 {
 	public class BoolGenerator : BaseRandomGenerator, IValueGenerator<bool>, IValueGenerator<bool?>
 	{

--- a/src/Untech.SharePoint.Common.Test/TestTools/Generators/Basic/DateTimeRangeGenerator.cs
+++ b/src/Untech.SharePoint.Common.Test/TestTools/Generators/Basic/DateTimeRangeGenerator.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Untech.SharePoint.Common.TestTools.Generators.Basic
+namespace Untech.SharePoint.TestTools.Generators.Basic
 {
 	public class DateTimeRangeGenerator : BaseRandomGenerator, IValueGenerator<DateTime>, IValueGenerator<DateTime?>
 	{

--- a/src/Untech.SharePoint.Common.Test/TestTools/Generators/Basic/DoubleRangeGenerator.cs
+++ b/src/Untech.SharePoint.Common.Test/TestTools/Generators/Basic/DoubleRangeGenerator.cs
@@ -1,4 +1,4 @@
-﻿namespace Untech.SharePoint.Common.TestTools.Generators.Basic
+﻿namespace Untech.SharePoint.TestTools.Generators.Basic
 {
 	public class DoubleRangeGenerator : BaseRandomGenerator, IValueGenerator<double>, IValueGenerator<double?>
 	{

--- a/src/Untech.SharePoint.Common.Test/TestTools/Generators/Basic/IntRangeGenerator.cs
+++ b/src/Untech.SharePoint.Common.Test/TestTools/Generators/Basic/IntRangeGenerator.cs
@@ -1,4 +1,4 @@
-﻿namespace Untech.SharePoint.Common.TestTools.Generators.Basic
+﻿namespace Untech.SharePoint.TestTools.Generators.Basic
 {
 	public class IntRangeGenerator : BaseRandomGenerator, IValueGenerator<int>, IValueGenerator<int?>
 	{

--- a/src/Untech.SharePoint.Common.Test/TestTools/Generators/Basic/LoremGenerator.cs
+++ b/src/Untech.SharePoint.Common.Test/TestTools/Generators/Basic/LoremGenerator.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Text;
 
-namespace Untech.SharePoint.Common.TestTools.Generators.Basic
+namespace Untech.SharePoint.TestTools.Generators.Basic
 {
 	public class LoremGenerator : BaseRandomGenerator, IValueGenerator<string>
 	{

--- a/src/Untech.SharePoint.Common.Test/TestTools/Generators/Basic/RangeGenerator.cs
+++ b/src/Untech.SharePoint.Common.Test/TestTools/Generators/Basic/RangeGenerator.cs
@@ -1,9 +1,9 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Extensions;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Extensions;
 
-namespace Untech.SharePoint.Common.TestTools.Generators.Basic
+namespace Untech.SharePoint.TestTools.Generators.Basic
 {
 	public class RangeGenerator<T> : BaseRandomGenerator, IValueGenerator<T>
 	{

--- a/src/Untech.SharePoint.Common.Test/TestTools/Generators/Basic/StaticGenerator.cs
+++ b/src/Untech.SharePoint.Common.Test/TestTools/Generators/Basic/StaticGenerator.cs
@@ -1,4 +1,4 @@
-﻿namespace Untech.SharePoint.Common.TestTools.Generators.Basic
+﻿namespace Untech.SharePoint.TestTools.Generators.Basic
 {
 	public class StaticGenerator<T> : IValueGenerator<T>
 	{

--- a/src/Untech.SharePoint.Common.Test/TestTools/Generators/Custom/UrlGenerator.cs
+++ b/src/Untech.SharePoint.Common.Test/TestTools/Generators/Custom/UrlGenerator.cs
@@ -1,8 +1,8 @@
 using System.Text;
-using Untech.SharePoint.Common.Models;
-using Untech.SharePoint.Common.TestTools.Generators.Basic;
+using Untech.SharePoint.Models;
+using Untech.SharePoint.TestTools.Generators.Basic;
 
-namespace Untech.SharePoint.Common.TestTools.Generators.Custom
+namespace Untech.SharePoint.TestTools.Generators.Custom
 {
 	public class UrlGenerator : BaseRandomGenerator, IValueGenerator<string>, IValueGenerator<UrlInfo>
 	{

--- a/src/Untech.SharePoint.Common.Test/TestTools/Generators/Custom/UserInfoGenerator.cs
+++ b/src/Untech.SharePoint.Common.Test/TestTools/Generators/Custom/UserInfoGenerator.cs
@@ -1,11 +1,11 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Extensions;
-using Untech.SharePoint.Common.Models;
-using Untech.SharePoint.Common.TestTools.Generators.Basic;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Extensions;
+using Untech.SharePoint.Models;
+using Untech.SharePoint.TestTools.Generators.Basic;
 
-namespace Untech.SharePoint.Common.TestTools.Generators.Custom
+namespace Untech.SharePoint.TestTools.Generators.Custom
 {
 	public class UserInfoGenerator : BaseRandomGenerator, IValueGenerator<UserInfo>
 	{

--- a/src/Untech.SharePoint.Common.Test/TestTools/Generators/GeneratorBehaviour.cs
+++ b/src/Untech.SharePoint.Common.Test/TestTools/Generators/GeneratorBehaviour.cs
@@ -1,4 +1,4 @@
-namespace Untech.SharePoint.Common.TestTools.Generators
+namespace Untech.SharePoint.TestTools.Generators
 {
 	public enum GeneratorBehaviour
 	{

--- a/src/Untech.SharePoint.Common.Test/TestTools/Generators/IValueGenerator.cs
+++ b/src/Untech.SharePoint.Common.Test/TestTools/Generators/IValueGenerator.cs
@@ -1,4 +1,4 @@
-﻿namespace Untech.SharePoint.Common.TestTools.Generators
+﻿namespace Untech.SharePoint.TestTools.Generators
 {
 	public interface IValueGenerator<out T>
 	{

--- a/src/Untech.SharePoint.Common.Test/TestTools/Generators/ObjectGenerator.cs
+++ b/src/Untech.SharePoint.Common.Test/TestTools/Generators/ObjectGenerator.cs
@@ -2,10 +2,10 @@ using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 using System.Reflection;
-using Untech.SharePoint.Common.CodeAnnotations;
-using Untech.SharePoint.Common.Utils.Reflection;
+using Untech.SharePoint.CodeAnnotations;
+using Untech.SharePoint.Utils.Reflection;
 
-namespace Untech.SharePoint.Common.TestTools.Generators
+namespace Untech.SharePoint.TestTools.Generators
 {
 	public class ObjectGenerator<T> : IValueGenerator<T>
 	{

--- a/src/Untech.SharePoint.Common.Test/TestTools/Generators/ObjectGeneratorExtensions.cs
+++ b/src/Untech.SharePoint.Common.Test/TestTools/Generators/ObjectGeneratorExtensions.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
-using Untech.SharePoint.Common.TestTools.Generators.Basic;
+using Untech.SharePoint.TestTools.Generators.Basic;
 
-namespace Untech.SharePoint.Common.TestTools.Generators
+namespace Untech.SharePoint.TestTools.Generators
 {
 	public static class ObjectGeneratorExtensions
 	{

--- a/src/Untech.SharePoint.Common.Test/TestTools/QueryTests/Attributes.cs
+++ b/src/Untech.SharePoint.Common.Test/TestTools/QueryTests/Attributes.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Untech.SharePoint.Common.TestTools.QueryTests
+namespace Untech.SharePoint.TestTools.QueryTests
 {
 	[AttributeUsage(AttributeTargets.Method)]
 	public class QueryComparerAttribute : Attribute

--- a/src/Untech.SharePoint.Common.Test/TestTools/QueryTests/ITestQueryAcceptor.cs
+++ b/src/Untech.SharePoint.Common.Test/TestTools/QueryTests/ITestQueryAcceptor.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Untech.SharePoint.Common.TestTools.QueryTests
+namespace Untech.SharePoint.TestTools.QueryTests
 {
 	public interface ITestQueryAcceptor<T>
 	{

--- a/src/Untech.SharePoint.Common.Test/TestTools/QueryTests/ITestQueryExcecutor.cs
+++ b/src/Untech.SharePoint.Common.Test/TestTools/QueryTests/ITestQueryExcecutor.cs
@@ -1,4 +1,4 @@
-namespace Untech.SharePoint.Common.TestTools.QueryTests
+namespace Untech.SharePoint.TestTools.QueryTests
 {
 	public interface ITestQueryExcecutor<T>
 	{

--- a/src/Untech.SharePoint.Common.Test/TestTools/QueryTests/ITestQueryProvider.cs
+++ b/src/Untech.SharePoint.Common.Test/TestTools/QueryTests/ITestQueryProvider.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Untech.SharePoint.Common.TestTools.QueryTests
+namespace Untech.SharePoint.TestTools.QueryTests
 {
 	public interface ITestQueryProvider<T>
 	{

--- a/src/Untech.SharePoint.Common.Test/TestTools/QueryTests/PerfTestQueryExecutor.cs
+++ b/src/Untech.SharePoint.Common.Test/TestTools/QueryTests/PerfTestQueryExecutor.cs
@@ -6,11 +6,11 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Untech.SharePoint.Common.Data;
-using Untech.SharePoint.Common.Extensions;
-using Untech.SharePoint.Common.MetaModels;
+using Untech.SharePoint.Data;
+using Untech.SharePoint.Extensions;
+using Untech.SharePoint.MetaModels;
 
-namespace Untech.SharePoint.Common.TestTools.QueryTests
+namespace Untech.SharePoint.TestTools.QueryTests
 {
 	public class PerfTestQueryExecutor<T> : ITestQueryExcecutor<T>
 	{

--- a/src/Untech.SharePoint.Common.Test/TestTools/QueryTests/SimpleTestQueryExecutor.cs
+++ b/src/Untech.SharePoint.Common.Test/TestTools/QueryTests/SimpleTestQueryExecutor.cs
@@ -2,9 +2,9 @@ using System;
 using System.Collections;
 using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Untech.SharePoint.Common.Data;
+using Untech.SharePoint.Data;
 
-namespace Untech.SharePoint.Common.TestTools.QueryTests
+namespace Untech.SharePoint.TestTools.QueryTests
 {
 	public class SimpleTestQueryExecutor<T> : ITestQueryExcecutor<T>
 	{

--- a/src/Untech.SharePoint.Common.Test/TestTools/QueryTests/TestQuery.cs
+++ b/src/Untech.SharePoint.Common.Test/TestTools/QueryTests/TestQuery.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Untech.SharePoint.Common.TestTools.QueryTests
+namespace Untech.SharePoint.TestTools.QueryTests
 {
 	public class TestQuery<T, TResult> : ITestQuery<T>
 	{

--- a/src/Untech.SharePoint.Common.Test/TestTools/QueryTests/TestQueryBuilder.cs
+++ b/src/Untech.SharePoint.Common.Test/TestTools/QueryTests/TestQueryBuilder.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Linq;
 using System.Reflection;
-using Untech.SharePoint.Common.Extensions;
-using Untech.SharePoint.Common.TestTools.Comparers;
+using Untech.SharePoint.Extensions;
+using Untech.SharePoint.TestTools.Comparers;
 
-namespace Untech.SharePoint.Common.TestTools.QueryTests
+namespace Untech.SharePoint.TestTools.QueryTests
 {
 	public class TestQueryBuilder<T> : ITestQueryAcceptor<T>
 	{


### PR DESCRIPTION
Move:

class | from NS | to NS
-----|-----------|----
(all stuff) | Untech.SharePoint.Common | Untech.SharePoint
`ServerConfig` class | Untech.SharePoint.Server.Configuration | Untech.SharePoint.Configuration
`SpServerCommonService` class | Untech.SharePoint.Server.Data | Untech.SharePoint.Data
`SpServerContext` class | Untech.SharePoint.Server.Data | Untech.SharePoint.Data
`ClientConfig` class | Untech.SharePoint.Client.Configuration | Untech.SharePoint.Configuration
`SpClientCommonService` class | Untech.SharePoint.Client.Data | Untech.SharePoint.Data
`SpClientContext` class | Untech.SharePoint.Client.Data | Untech.SharePoint.Data